### PR TITLE
Fix: cuCtxCreate before other initialization

### DIFF
--- a/src/kernels/cuda/conv.cc
+++ b/src/kernels/cuda/conv.cc
@@ -240,7 +240,8 @@ class convCudnn : public Kernel {
                     ALGOS[record.algo], &record.workspaceSize);
                 if (stat != CUDNN_STATUS_SUCCESS)
                     continue;
-
+                if (record.workspaceSize > context->getWorkspaceSize())
+                    continue;
                 CudaPtr wsData = context->getWorkspace(record.workspaceSize);
                 float alpha = 1.f, beta = 0.f;
 

--- a/src/operators/matmul.cc
+++ b/src/operators/matmul.cc
@@ -17,7 +17,7 @@ string MatmulObj::toString() const {
     os << "Matmul([" << (transA ? "A^T" : "A") << "," << (transB ? "B^T" : "B")
        << ",act=" << enum_to_underlying(act) << "],A=" << inputs[0]->getGuid()
        << ",B=" << inputs[1]->getGuid() << ",C=" << outputs[0]->getGuid()
-       << ")";
+       << ",bmnk=[" << b << "," << m << "," << n << "," << k << "])";
     return os.str();
 }
 


### PR DESCRIPTION
```
      Start  1: test_graph
 1/36 Test  #1: test_graph .......................   Passed    0.04 sec
      Start  2: test_hash
 2/36 Test  #2: test_hash ........................   Passed    0.03 sec
      Start  3: test_tensor_save
 3/36 Test  #3: test_tensor_save .................   Passed    0.02 sec
      Start  4: test_verify
 4/36 Test  #4: test_verify ......................   Passed    0.02 sec
      Start  5: test_batch_norm
 5/36 Test  #5: test_batch_norm ..................   Passed    0.02 sec
      Start  6: test_concat
 6/36 Test  #6: test_concat ......................   Passed    0.02 sec
      Start  7: test_conv
 7/36 Test  #7: test_conv ........................   Passed    1.86 sec
      Start  8: test_conv_transposed_2d
 8/36 Test  #8: test_conv_transposed_2d ..........   Passed    0.02 sec
      Start  9: test_element_wise
 9/36 Test  #9: test_element_wise ................   Passed    0.02 sec
      Start 10: test_extend
10/36 Test #10: test_extend ......................   Passed    0.02 sec
      Start 11: test_gather
11/36 Test #11: test_gather ......................   Passed    0.02 sec
      Start 12: test_matmul
12/36 Test #12: test_matmul ......................   Passed    0.02 sec
      Start 13: test_pad
13/36 Test #13: test_pad .........................   Passed    0.02 sec
      Start 14: test_pooling
14/36 Test #14: test_pooling .....................   Passed    0.02 sec
      Start 15: test_reduce_mean
15/36 Test #15: test_reduce_mean .................   Passed    0.02 sec
      Start 16: test_reshape
16/36 Test #16: test_reshape .....................   Passed    0.02 sec
      Start 17: test_slice
17/36 Test #17: test_slice .......................   Passed    0.02 sec
      Start 18: test_split
18/36 Test #18: test_split .......................   Passed    0.02 sec
      Start 19: test_cuda_G2BMM
19/36 Test #19: test_cuda_G2BMM ..................   Passed    4.26 sec
      Start 20: test_cuda_GBMM
20/36 Test #20: test_cuda_GBMM ...................   Passed    5.13 sec
      Start 21: test_cuda_batch_norm
21/36 Test #21: test_cuda_batch_norm .............   Passed    4.52 sec
      Start 22: test_cuda_concat
22/36 Test #22: test_cuda_concat .................   Passed    4.36 sec
      Start 23: test_cuda_conv
23/36 Test #23: test_cuda_conv ...................   Passed   15.50 sec
      Start 24: test_cuda_conv_transposed_2d
24/36 Test #24: test_cuda_conv_transposed_2d .....   Passed   11.89 sec
      Start 25: test_cuda_element_wise
25/36 Test #25: test_cuda_element_wise ...........   Passed   15.98 sec
      Start 26: test_cuda_extend
26/36 Test #26: test_cuda_extend .................   Passed    4.75 sec
      Start 27: test_cuda_gather
27/36 Test #27: test_cuda_gather .................   Passed    9.58 sec
      Start 28: test_cuda_matmul
28/36 Test #28: test_cuda_matmul .................   Passed   11.62 sec
      Start 29: test_cuda_pad
29/36 Test #29: test_cuda_pad ....................   Passed    4.18 sec
      Start 30: test_cuda_pooling
30/36 Test #30: test_cuda_pooling ................   Passed    6.68 sec
      Start 31: test_cuda_reduce_mean
31/36 Test #31: test_cuda_reduce_mean ............   Passed   12.07 sec
      Start 32: test_cuda_reshape
32/36 Test #32: test_cuda_reshape ................   Passed   10.15 sec
      Start 33: test_cuda_slice
33/36 Test #33: test_cuda_slice ..................   Passed    3.84 sec
      Start 34: test_cuda_split
34/36 Test #34: test_cuda_split ..................   Passed    4.21 sec
      Start 35: test_cuda_unary
35/36 Test #35: test_cuda_unary ..................   Passed   14.71 sec
      Start 36: test_perfengine
36/36 Test #36: test_perfengine ..................   Passed    6.54 sec

100% tests passed, 0 tests failed out of 36

Total Test time (real) = 152.21 sec```