### PR TITLE
Fix: fix bugs for intelcpu while testing onnx models.

### DIFF
--- a/include/core/graph_handler.h
+++ b/include/core/graph_handler.h
@@ -50,7 +50,7 @@ class GraphHandlerObj {
                             int pw, int sh, int sw, int dh, int dw, int oph,
                             int opw);
     Tensor matmul(Tensor a, Tensor b, Tensor y, bool transA, bool transB,
-                  Tensor bias, ActType act);
+                  float alpha, float beta, Tensor bias, ActType act);
     Tensor batchNorm(Tensor input, Tensor output, Tensor mean, Tensor var,
                      Tensor scale, Tensor bias, float momentum, float eps,
                      bool training);

--- a/include/intelcpu/mkl_kernel_without_config.h
+++ b/include/intelcpu/mkl_kernel_without_config.h
@@ -24,7 +24,9 @@ class MklKernelWithoutConfig : public Kernel {
 
   protected:
     dnnl::memory::format_tag getUserFormatTag(int nDim) const {
-        if (nDim == 2)
+        if (nDim == 1)
+            return dnnl::memory::format_tag::x;
+        else if (nDim == 2)
             return dnnl::memory::format_tag::nc;
         else if (nDim == 3)
             return dnnl::memory::format_tag::ncw;

--- a/include/operators/matmul.h
+++ b/include/operators/matmul.h
@@ -12,6 +12,8 @@ class MatmulObj : public OperatorObj {
     // default dims, true means A should be transposed before matmul. This is in
     // oppsite to the column-major BLAS.
     bool transA, transB;
+    float alpha, beta;
+
     ActType act;
 
     // Auxiliary attributes which are not a part of operator attributes.
@@ -40,7 +42,8 @@ class MatmulObj : public OperatorObj {
      * @param act The activation function.
      */
     MatmulObj(GraphObj *graph, Tensor A, Tensor B, Tensor C,
-              bool transA = false, bool transB = false, Tensor bias = nullptr,
+              bool transA = false, bool transB = false, float alpha = 1,
+              float beta = 0, Tensor bias = nullptr,
               ActType act = ActType::None);
     OP_CLONE(MatmulObj);
 
@@ -60,6 +63,8 @@ class MatmulObj : public OperatorObj {
     int getN() const { return n; }
     int getK() const { return k; }
     auto getBMNK() const { return tuple{b, m, n, k}; }
+    float getAlpha() const { return alpha; }
+    float getBeta() const { return beta; }
 
   private:
     vector<int> getWorkloadVector() const override;

--- a/src/core/graph_handler.cc
+++ b/src/core/graph_handler.cc
@@ -56,15 +56,17 @@ Tensor GraphHandlerObj::convTransposed2d(Tensor input, Tensor weight,
 }
 
 Tensor GraphHandlerObj::matmul(Tensor a, Tensor b, Tensor y, bool transA,
-                               bool transB, Tensor bias, ActType act) {
+                               bool transB, float alpha, float beta,
+                               Tensor bias, ActType act) {
     if (y) {
         g->addOpWithOutputs<MatmulObj>(std::move(a), std::move(b), y, transA,
-                                       transB, std::move(bias), act);
+                                       transB, alpha, beta, std::move(bias),
+                                       act);
         return y;
     } else {
         return g
             ->addOp<MatmulObj>(std::move(a), std::move(b), y, transA, transB,
-                               std::move(bias), act)
+                               alpha, beta, std::move(bias), act)
             ->getOutput();
     }
 }

--- a/src/kernels/cuda/gather.cc
+++ b/src/kernels/cuda/gather.cc
@@ -12,6 +12,8 @@ class GatherCuda : public CudaKernelWithoutConfig {
         auto in = op->getInputs(0);
         auto index = op->getInputs(1);
         auto out = op->getOutput();
+        if (!(index->getDType() == DataType::Int32))
+            IT_ASSERT_TODO();
         metaData.indexValue = index->getRawDataPtr<int *>();
         metaData.axis = op->getAxis();
         metaData.inNDim = in->getDims().size();

--- a/src/kernels/intelcpu/transpose.cc
+++ b/src/kernels/intelcpu/transpose.cc
@@ -1,0 +1,70 @@
+#include "operators/transpose.h"
+#include "intelcpu/mkl_kernel_without_config.h"
+#include "intelcpu/mkl_runtime.h"
+
+namespace infini {
+class MklTranspose : public MklKernelWithoutConfig {
+    void compute(const Operator &_op,
+                 const RuntimeObj *_context) const override {
+        auto op = as<TransposeObj>(_op);
+        auto context = dynamic_cast<const MklRuntimeObj *>(_context);
+
+        std::vector<dnnl_dim_t> dims;
+        for (size_t i = 0; i < op->getInputs(0)->getDims().size(); ++i)
+            dims.push_back(op->getInputs(0)->getDims()[i]);
+
+        // create src md and src memory
+        auto srcMd = dnnl::memory::desc(dims, dnnl::memory::data_type::f32,
+                                        getUserFormatTag(dims.size()));
+
+        // dst md
+        auto oDims = op->getOutput(0)->getDims();
+        int ndim = oDims.size();
+        std::vector<dnnl_dim_t> dstDims;
+        Shape permute = op->getPermute(), ori_permute = op->getPermute();
+        for (int i = 0; i < ndim; ++i) {
+            dstDims.push_back(oDims.at(i));
+            permute[i] = std::find(ori_permute.begin(), ori_permute.end(), i) -
+                         ori_permute.begin();
+        }
+
+        auto permuteMd = srcMd.permute_axes(permute);
+        auto permuteMemory =
+            dnnl::memory(permuteMd, context->getEngine(),
+                         op->getInputs(0)->getRawDataPtr<float *>());
+
+        auto userDstMd =
+            dnnl::memory::desc(dstDims, dnnl::memory::data_type::f32,
+                               getUserFormatTag(dstDims.size()));
+        auto output = dnnl::memory(userDstMd, context->getEngine(),
+                                   op->getOutput(0)->getRawDataPtr<float *>());
+
+        // Create memory for output
+        if (permuteMd == userDstMd) {
+            auto output =
+                dnnl::memory(userDstMd, context->getEngine(),
+                             op->getOutput(0)->getRawDataPtr<float *>());
+
+            // copy data to dst
+            dnnl::reorder(permuteMemory, output)
+                .execute(context->getStream(), {{DNNL_ARG_FROM, permuteMemory},
+                                                {DNNL_ARG_TO, output}});
+        } else {
+            auto dstMemory = dnnl::memory(permuteMd, context->getEngine());
+            // copy data to dst
+            dnnl::reorder(permuteMemory, dstMemory)
+                .execute(context->getStream(), {{DNNL_ARG_FROM, permuteMemory},
+                                                {DNNL_ARG_TO, dstMemory}});
+
+            auto output =
+                dnnl::memory(userDstMd, context->getEngine(),
+                             op->getOutput(0)->getRawDataPtr<float *>());
+            dnnl::reorder(dstMemory, output)
+                .execute(context->getStream(),
+                         {{DNNL_ARG_FROM, dstMemory}, {DNNL_ARG_TO, output}});
+        }
+    }
+};
+REGISTER_KERNEL(Device::INTELCPU, OpType::Transpose, DataType::Float32,
+                MklTranspose, "Transpose_Mkl_Float32");
+}; // namespace infini

--- a/src/operators/conv.cc
+++ b/src/operators/conv.cc
@@ -85,6 +85,7 @@ ConvObj::ConvObj(GraphObj *graph, Tensor input, Tensor weight, Tensor output,
 
 optional<vector<Shape>> ConvObj::inferShape(const TensorVec &inputs) const {
     const auto &input = inputs[0], &weight = inputs[1];
+    IT_ASSERT_TODO(input->getDims().size() == 4);
     auto n = input->getDims()[0];
     auto h = input->getDims()[2];
     auto w = input->getDims()[3];

--- a/src/operators/gather.cc
+++ b/src/operators/gather.cc
@@ -28,7 +28,8 @@ optional<vector<Shape>> GatherObj::inferShape(const TensorVec &inputs) const {
 vector<DataType> GatherObj::inferDataType(const TensorVec &inputs) const {
     IT_ASSERT(inputs.size() == 2);
     auto index = inputs[1];
-    IT_ASSERT(index->getDType() == DataType::UInt32);
+    IT_ASSERT(index->getDType() == DataType::Int32 ||
+              index->getDType() == DataType::Int64);
     return {inputs[0]->getDType()};
 }
 

--- a/src/operators/matmul.cc
+++ b/src/operators/matmul.cc
@@ -3,10 +3,11 @@
 namespace infini {
 
 MatmulObj::MatmulObj(GraphObj *graph, Tensor A, Tensor B, Tensor C, bool transA,
-                     bool transB, [[maybe_unused]] Tensor bias, ActType act)
+                     bool transB, float alpha, float beta, Tensor bias,
+                     ActType act)
     : OperatorObj(OpType::Matmul,
                   bias ? TensorVec{A, B, bias} : TensorVec{A, B}, {C}),
-      transA(transA), transB(transB), act(act), b(1) {
+      transA(transA), transB(transB), alpha(alpha), beta(beta), act(act), b(1) {
     auto shape_a = A->getDims();
     auto shape_b = B->getDims();
     int dimA = shape_a.size(), dimB = shape_b.size();

--- a/test/core/test_graph_handler.cc
+++ b/test/core/test_graph_handler.cc
@@ -10,7 +10,7 @@ TEST(Handler, matmul) {
     auto i = handler->tensor({1, 2, 3}, OnnxDType::UINT32);
     auto w = handler->tensor({1, 3, 4}, OnnxDType::UINT32);
     auto o = handler->tensor({1, 2, 4}, OnnxDType::UINT32);
-    handler->matmul(i, w, o, false, false, nullptr, ActType::None);
+    handler->matmul(i, w, o, false, false, 1, 0, nullptr, ActType::None);
 }
 
 } // namespace infini

--- a/test/kernels/cuda/test_cuda_gather.cc
+++ b/test/kernels/cuda/test_cuda_gather.cc
@@ -179,10 +179,10 @@ TEST(Gather, Cuda) {
         Runtime runtime = NativeCpuRuntimeObj::getInstance();
         Graph gCpu = make_ref<GraphObj>(runtime);
         auto input = gCpu->addTensor({3, 2}, DataType::Float32);
-        auto index = gCpu->addTensor({2, 2}, DataType::UInt32);
+        auto index = gCpu->addTensor({2, 2}, DataType::Int32);
         gCpu->dataMalloc();
         input->copyin(vector<float>{1, 2, 3, 4, 5, 6});
-        index->copyin(vector<uint32_t>{0, 1, 1, 2});
+        index->copyin(vector<int32_t>{0, 1, 1, 2});
         auto cudaRuntime = make_ref<CudaRuntimeObj>();
         Graph gCuda = make_ref<GraphObj>(cudaRuntime);
 
@@ -200,10 +200,10 @@ TEST(Gather, Cuda) {
         Runtime runtime = NativeCpuRuntimeObj::getInstance();
         Graph gCpu = make_ref<GraphObj>(runtime);
         auto input = gCpu->addTensor({3, 3}, DataType::Float32);
-        auto index = gCpu->addTensor({1, 2}, DataType::UInt32);
+        auto index = gCpu->addTensor({1, 2}, DataType::Int32);
         gCpu->dataMalloc();
         input->setData(IncrementalGenerator());
-        index->copyin(vector<uint32_t>{0, 2});
+        index->copyin(vector<int32_t>{0, 2});
         auto cudaRuntime = make_ref<CudaRuntimeObj>();
         Graph gCuda = make_ref<GraphObj>(cudaRuntime);
 
@@ -221,10 +221,10 @@ TEST(Gather, Cuda) {
         Runtime runtime = NativeCpuRuntimeObj::getInstance();
         Graph gCpu = make_ref<GraphObj>(runtime);
         auto input = gCpu->addTensor({2, 4, 2}, DataType::Float32);
-        auto index = gCpu->addTensor({3, 1}, DataType::UInt32);
+        auto index = gCpu->addTensor({3, 1}, DataType::Int32);
         gCpu->dataMalloc();
         input->setData(IncrementalGenerator());
-        index->copyin(vector<uint32_t>{0, 3, 1});
+        index->copyin(vector<int32_t>{0, 3, 1});
         auto cudaRuntime = make_ref<CudaRuntimeObj>();
         Graph gCuda = make_ref<GraphObj>(cudaRuntime);
 

--- a/test/kernels/intelcpu/test_mkl_conv.cc
+++ b/test/kernels/intelcpu/test_mkl_conv.cc
@@ -36,6 +36,30 @@ TEST(dnnl_Conv, run) {
         vector<float>{4794, 4386, 8199, 7506, 11274, 10542, 20835, 19656});
 }
 
+TEST(mkl_Conv, groups) {
+    auto mklRuntime = MklRuntimeObj::getInstance();
+    Graph gMkl = make_ref<GraphObj>(mklRuntime);
+
+    Tensor i0 = gMkl->addTensor({1, 3, 4, 4}, DataType::Float32);
+    Tensor w0 = gMkl->addTensor({3, 1, 3, 3}, DataType::Float32);
+
+    // Build  graph
+    auto conv = gMkl->addOp<ConvObj>(i0, w0, nullptr, 1, 1, 1, 1, 1, 1);
+    // Malloc data for all tensors in a graph.
+    gMkl->dataMalloc();
+    i0->setData(IncrementalGenerator());
+    w0->setData(IncrementalGenerator());
+
+    mklRuntime->run(gMkl);
+
+    EXPECT_TRUE(conv->getOutput(0)->equalData(vector<float>{
+        73,   121,  154,  103,  171,  258,  294,  186,  279,  402,
+        438,  270,  139,  187,  202,  113,  1123, 1675, 1762, 1161,
+        1710, 2535, 2652, 1737, 2034, 3003, 3120, 2037, 1285, 1885,
+        1954, 1267, 3325, 4957, 5098, 3371, 4977, 7404, 7602, 5016,
+        5517, 8196, 8394, 5532, 3583, 5311, 5434, 3573}));
+}
+
 TEST(mkl_Conv, tune) {
     auto mklRuntime = MklRuntimeObj::getInstance();
     Graph gMkl = make_ref<GraphObj>(mklRuntime);

--- a/test/kernels/intelcpu/test_mkl_element_wise.cc
+++ b/test/kernels/intelcpu/test_mkl_element_wise.cc
@@ -81,4 +81,59 @@ TEST(dnnl_Unary, run) {
     testUnary<TanhObj>(IncrementalGenerator(), Shape{1, 2, 2, 3});
 }
 
+TEST(dnnl_clip, run) {
+    auto rMkl = make_ref<MklRuntimeObj>();
+
+    // MKL
+    Graph gMkl = make_ref<GraphObj>(rMkl);
+    auto iMkl = gMkl->addTensor(Shape{1, 2, 2, 3}, DataType::Float32);
+    auto opMkl = gMkl->addOp<ClipObj>(iMkl, nullptr, 3, 7);
+    gMkl->dataMalloc();
+    iMkl->copyin(vector<float>{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12});
+    rMkl->run(gMkl);
+
+    // Check
+    EXPECT_TRUE(opMkl->getOutput()->equalData(
+        vector<float>{3, 3, 3, 4, 5, 6, 7, 7, 7, 7, 7, 7}));
+}
+
+template <class T>
+void testBinaryBroadcast(
+    const std::function<void(void *, size_t, DataType)> &generator,
+    const Shape &shapeA, const Shape &shapeB, const ExpectOutput &ansVec) {
+    Runtime runtime = MklRuntimeObj::getInstance();
+    Graph g = make_ref<GraphObj>(runtime);
+    auto a = g->addTensor(shapeA, DataType::Float32);
+    auto b = g->addTensor(shapeB, DataType::Float32);
+    auto op = g->addOp<T>(a, b, nullptr);
+    g->dataMalloc();
+    a->setData(generator);
+    b->setData(generator);
+
+    runtime->run(g);
+
+    auto c = op->getOutput();
+    //  check results on CPU
+    EXPECT_TRUE(c->equalData(ansVec));
+}
+
+TEST(dnnl_Binary_broadcast, run) {
+    testBinaryBroadcast<AddObj>(
+        IncrementalGenerator(), Shape{1, 2, 2, 3}, Shape{2, 1, 2, 1},
+        ExpectOutput{0., 1., 2., 4., 5., 6., 6., 7., 8.,  10., 11., 12.,
+                     2., 3., 4., 6., 7., 8., 8., 9., 10., 12., 13., 14.});
+    testBinaryBroadcast<AddObj>(
+        IncrementalGenerator(), Shape{1, 4, 5}, Shape{2, 3, 1, 1},
+        ExpectOutput{0.,  1.,  2.,  3.,  4.,  5.,  6.,  7.,  8.,  9.,  10.,
+                     11., 12., 13., 14., 15., 16., 17., 18., 19., 1.,  2.,
+                     3.,  4.,  5.,  6.,  7.,  8.,  9.,  10., 11., 12., 13.,
+                     14., 15., 16., 17., 18., 19., 20., 2.,  3.,  4.,  5.,
+                     6.,  7.,  8.,  9.,  10., 11., 12., 13., 14., 15., 16.,
+                     17., 18., 19., 20., 21., 3.,  4.,  5.,  6.,  7.,  8.,
+                     9.,  10., 11., 12., 13., 14., 15., 16., 17., 18., 19.,
+                     20., 21., 22., 4.,  5.,  6.,  7.,  8.,  9.,  10., 11.,
+                     12., 13., 14., 15., 16., 17., 18., 19., 20., 21., 22.,
+                     23., 5.,  6.,  7.,  8.,  9.,  10., 11., 12., 13., 14.,
+                     15., 16., 17., 18., 19., 20., 21., 22., 23., 24.});
+}
 }; // namespace infini

--- a/test/kernels/intelcpu/test_mkl_gather.cc
+++ b/test/kernels/intelcpu/test_mkl_gather.cc
@@ -7,15 +7,15 @@
 #include "test.h"
 
 namespace infini {
-TEST(Gather, Cuda) {
+TEST(Gather, Mkl) {
     {
         Runtime runtime = MklRuntimeObj::getInstance();
         Graph g = make_ref<GraphObj>(runtime);
         auto input = g->addTensor({3, 2}, DataType::Float32);
-        auto index = g->addTensor({2, 2}, DataType::UInt32);
+        auto index = g->addTensor({2, 2}, DataType::Int32);
         g->dataMalloc();
         input->copyin(vector<float>{1, 2, 3, 4, 5, 6});
-        index->copyin(vector<uint32_t>{0, 1, 1, 2});
+        index->copyin(vector<int32_t>{0, 1, 1, 2});
 
         auto op = g->addOp<GatherObj>(input, index, nullptr, 0);
         g->dataMalloc();
@@ -28,10 +28,10 @@ TEST(Gather, Cuda) {
         Runtime runtime = MklRuntimeObj::getInstance();
         Graph g = make_ref<GraphObj>(runtime);
         auto input = g->addTensor({3, 3}, DataType::Float32);
-        auto index = g->addTensor({1, 2}, DataType::UInt32);
+        auto index = g->addTensor({1, 2}, DataType::Int64);
         g->dataMalloc();
         input->setData(IncrementalGenerator());
-        index->copyin(vector<uint32_t>{0, 2});
+        index->copyin(vector<int64_t>{0, 2});
 
         auto op = g->addOp<GatherObj>(input, index, nullptr, 1);
         g->dataMalloc();
@@ -44,10 +44,10 @@ TEST(Gather, Cuda) {
         Runtime runtime = MklRuntimeObj::getInstance();
         Graph g = make_ref<GraphObj>(runtime);
         auto input = g->addTensor({2, 4, 2}, DataType::Float32);
-        auto index = g->addTensor({3, 1}, DataType::UInt32);
+        auto index = g->addTensor({3, 1}, DataType::Int32);
         g->dataMalloc();
         input->setData(IncrementalGenerator());
-        index->copyin(vector<uint32_t>{0, 3, 1});
+        index->copyin(vector<int32_t>{0, 3, 1});
 
         auto op = g->addOp<GatherObj>(input, index, nullptr, 1);
         g->dataMalloc();

--- a/test/kernels/intelcpu/test_mkl_matmul.cc
+++ b/test/kernels/intelcpu/test_mkl_matmul.cc
@@ -40,4 +40,24 @@ TEST(mkl_Matmul, run) {
                                475, 448, 502, 472, 529});
 }
 
+TEST(mkl_Matmul_with_Bias, run) {
+    auto cpuRuntime = MklRuntimeObj::getInstance();
+    Graph gCpu = make_ref<GraphObj>(cpuRuntime);
+    auto ACpu = gCpu->addTensor(Shape{3, 4}, DataType::Float32);
+    auto BCpu = gCpu->addTensor(Shape{4, 2}, DataType::Float32);
+    auto bias = gCpu->addTensor(Shape{3, 2}, DataType::Float32);
+    gCpu->dataMalloc();
+    ACpu->setData(IncrementalGenerator());
+    BCpu->setData(IncrementalGenerator());
+    bias->setData(IncrementalGenerator());
+
+    auto matmul =
+        gCpu->addOp<MatmulObj>(ACpu, BCpu, nullptr, false, false, 1, 1, bias);
+
+    gCpu->dataMalloc();
+    cpuRuntime->run(gCpu);
+    EXPECT_TRUE(matmul->getOutput()->equalData(
+        vector<float>{28., 35., 78., 101., 128., 167.}));
+}
+
 }; // namespace infini

--- a/test/kernels/intelcpu/test_mkl_transpose.cc
+++ b/test/kernels/intelcpu/test_mkl_transpose.cc
@@ -1,0 +1,27 @@
+#include "core/graph.h"
+#include "core/runtime.h"
+#include "intelcpu/mkl_runtime.h"
+#include "operators/transpose.h"
+
+#include "test.h"
+
+namespace infini {
+
+TEST(Transpose, Mkl) {
+    Runtime runtime = MklRuntimeObj::getInstance();
+    Graph g = make_ref<GraphObj>(runtime);
+
+    auto input = g->addTensor({2, 3, 1, 2}, DataType::Float32);
+    auto op = g->addOp<TransposeObj>(input, nullptr, Shape{0, 2, 3, 1});
+    g->dataMalloc();
+    input->setData(IncrementalGenerator());
+
+    runtime->run(g);
+
+    auto o = g->cloneTensor(op->getOutput(0));
+    //  check results
+    EXPECT_TRUE(o->equalData(
+        vector<float>{0., 2., 4., 1., 3., 5., 6., 8., 10., 7., 9., 11.}));
+}
+
+} // namespace infini

--- a/test/operators/test_element_wise.cc
+++ b/test/operators/test_element_wise.cc
@@ -19,4 +19,14 @@ TEST(ElementWise, ShapeInference) {
     }
 }
 
+TEST(ElementWise, ShapeInference_bc) {
+    Runtime runtime = NativeCpuRuntimeObj::getInstance();
+    {
+        Graph g = make_ref<GraphObj>(runtime);
+        Tensor i0 = g->addTensor({4, 5}, DataType::UInt32);
+        Tensor i1 = g->addTensor({2, 3, 1, 1}, DataType::UInt32);
+        auto op = g->addOp<AddObj>(i0, i1, nullptr);
+        EXPECT_EQ(op->getOutput()->getDims(), (Shape{2, 3, 4, 5}));
+    }
+}
 } // namespace infini

--- a/test/operators/test_gather.cc
+++ b/test/operators/test_gather.cc
@@ -11,8 +11,8 @@ TEST(Gather, ShapeInference) {
     Runtime runtime = NativeCpuRuntimeObj::getInstance();
 
     Graph g = make_ref<GraphObj>(runtime);
-    Tensor i = g->addTensor({1, 3, 4, 4}, DataType::UInt32);
-    Tensor index = g->addTensor({2, 1, 2}, DataType::UInt32);
+    Tensor i = g->addTensor({1, 3, 4, 4}, DataType::Int32);
+    Tensor index = g->addTensor({2, 1, 2}, DataType::Int32);
     auto op = g->addOp<GatherObj>(i, index, nullptr, 1);
     EXPECT_EQ(op->getOutput()->getDims(), (Shape{1, 2, 1, 2, 4, 4}));
 }


### PR DESCRIPTION
fix unsqueeze parse

fix parsing constant tensor converted from simplify.

fix index datatype for gather

fix multidirectional broadcasting for intelcpu

fix transpose

add transpose kernel for intelcpu

fix matmul with alpha/beta

fix matmul dpcpp with bias

fix pad parsing

support broadcast for binary op kernel.

fix some for intelcpu model test

```

      Start  1: test_graph
 1/40 Test  #1: test_graph .......................   Passed    0.27 sec
      Start  2: test_graph_handler
 2/40 Test  #2: test_graph_handler ...............   Passed    0.27 sec
      Start  3: test_graph_replace
 3/40 Test  #3: test_graph_replace ...............   Passed    0.30 sec
      Start  4: test_hash
 4/40 Test  #4: test_hash ........................   Passed    0.25 sec
      Start  5: test_search
 5/40 Test  #5: test_search ......................   Passed   30.37 sec
      Start  6: test_tensor_save
 6/40 Test  #6: test_tensor_save .................   Passed    0.26 sec
      Start  7: test_verify
 7/40 Test  #7: test_verify ......................   Passed    0.25 sec
      Start  8: test_batch_norm
 8/40 Test  #8: test_batch_norm ..................   Passed    0.26 sec
      Start  9: test_clip
 9/40 Test  #9: test_clip ........................   Passed    0.26 sec
      Start 10: test_concat
10/40 Test #10: test_concat ......................   Passed    0.29 sec
      Start 11: test_conv
11/40 Test #11: test_conv ........................   Passed    0.25 sec
      Start 12: test_conv_transposed_2d
12/40 Test #12: test_conv_transposed_2d ..........   Passed    0.26 sec
      Start 13: test_element_wise
13/40 Test #13: test_element_wise ................   Passed    0.27 sec
      Start 14: test_extend
14/40 Test #14: test_extend ......................   Passed    0.26 sec
      Start 15: test_gather
15/40 Test #15: test_gather ......................   Passed    0.26 sec
      Start 16: test_matmul
16/40 Test #16: test_matmul ......................   Passed    0.26 sec
      Start 17: test_pad
17/40 Test #17: test_pad .........................   Passed    0.27 sec
      Start 18: test_pooling
18/40 Test #18: test_pooling .....................   Passed    0.26 sec
      Start 19: test_reduce_mean
19/40 Test #19: test_reduce_mean .................   Passed    0.26 sec
      Start 20: test_reshape
20/40 Test #20: test_reshape .....................   Passed    0.26 sec
      Start 21: test_resize
21/40 Test #21: test_resize ......................   Passed    0.26 sec
      Start 22: test_slice
22/40 Test #22: test_slice .......................   Passed    0.26 sec
      Start 23: test_split
23/40 Test #23: test_split .......................   Passed    0.28 sec
      Start 24: test_mkl_batch_norm
24/40 Test #24: test_mkl_batch_norm ..............   Passed    0.31 sec
      Start 25: test_mkl_concat
25/40 Test #25: test_mkl_concat ..................   Passed    0.39 sec
      Start 26: test_mkl_conv
26/40 Test #26: test_mkl_conv ....................   Passed    0.70 sec
      Start 27: test_mkl_conv_transposed
27/40 Test #27: test_mkl_conv_transposed .........   Passed    0.89 sec
      Start 28: test_mkl_element_wise
28/40 Test #28: test_mkl_element_wise ............   Passed    1.00 sec
      Start 29: test_mkl_extend
29/40 Test #29: test_mkl_extend ..................   Passed    0.81 sec
      Start 30: test_mkl_gather
30/40 Test #30: test_mkl_gather ..................   Passed    1.45 sec
      Start 31: test_mkl_matmul
31/40 Test #31: test_mkl_matmul ..................   Passed    0.92 sec
      Start 32: test_mkl_pad
32/40 Test #32: test_mkl_pad .....................   Passed    0.29 sec
      Start 33: test_mkl_pooling
33/40 Test #33: test_mkl_pooling .................   Passed    0.34 sec
      Start 34: test_mkl_reduce
34/40 Test #34: test_mkl_reduce ..................   Passed    0.31 sec
      Start 35: test_mkl_reshape
35/40 Test #35: test_mkl_reshape .................   Passed    0.43 sec
      Start 36: test_mkl_resize
36/40 Test #36: test_mkl_resize ..................   Passed    0.26 sec
      Start 37: test_mkl_slice
37/40 Test #37: test_mkl_slice ...................   Passed    0.33 sec
      Start 38: test_mkl_softmax
38/40 Test #38: test_mkl_softmax .................   Passed    0.29 sec
      Start 39: test_mkl_split
39/40 Test #39: test_mkl_split ...................   Passed    0.31 sec
      Start 40: test_mkl_transpose
40/40 Test #40: test_mkl_transpose ...............   Passed    0.42 sec

100% tests passed, 0 tests failed out of 40

Total Test time (real) =  45.69 sec
```
