### PR TITLE
支持fp16 dtype

### DIFF
--- a/include/core/data_type.h
+++ b/include/core/data_type.h
@@ -4,8 +4,6 @@ namespace infini {
 
 class DataType {
   public:
-    // legacy
-    // These are just aligned with the type and index of onnx:
     // <https://onnx.ai/onnx/intro/concepts.html#element-type>
     static const DataType Float32;
     static const DataType UInt32;
@@ -17,6 +15,8 @@ class DataType {
     static const DataType Int64;
     static const DataType Bool;
     static const DataType Float16;
+    // "sizePerElement" show the DType to cpu_type
+    // DataType::Bool -> int8_t   DataType::Float16 -> uint8_t
     static constexpr size_t sizePerElement[]{
         sizeof(float),    sizeof(uint32_t), sizeof(uint8_t), sizeof(int8_t),
         sizeof(uint16_t), sizeof(int16_t),  sizeof(int32_t), sizeof(int64_t),
@@ -26,7 +26,7 @@ class DataType {
         "Float32", "UInt32", "UInt8", "Int8", "UInt16",
         "Int16",   "Int32",  "Int64", "Bool", "Float16"};
 
-    static constexpr std::string_view sizetostring[]{
+    static constexpr std::string_view cpuType[]{
         "float",   "uint32_t", "uint8_t", "int8_t", "uint16_t",
         "int16_t", "int32_t",  "int64_t", "int8_t", "uint8_t"};
 
@@ -46,7 +46,7 @@ class DataType {
     }
     size_t getSize() const { return sizePerElement[index]; }
     string toString() const { return string(names[index]); }
-    string sizetoString() const { return string(sizetostring[index]); }
+    string cpuTypeString() const { return string(cpuType[index]); }
 };
 
 inline const DataType DataType::Float32(0);
@@ -66,35 +66,15 @@ template <> inline std::string DataType::get<int32_t>() { return "int32_t"; }
 template <> inline std::string DataType::get<int64_t>() { return "int64_t"; }
 
 template <int index> struct DT {};
-template <> struct DT<0> {
-    using t = float;
-};
-template <> struct DT<1> {
-    using t = uint32_t;
-};
-template <> struct DT<2> {
-    using t = uint8_t;
-};
-template <> struct DT<3> {
-    using t = int8_t;
-};
-template <> struct DT<4> {
-    using t = uint16_t;
-};
-template <> struct DT<5> {
-    using t = int16_t;
-};
-template <> struct DT<6> {
-    using t = int32_t;
-};
-template <> struct DT<7> {
-    using t = int64_t;
-};
-template <> struct DT<8> {
-    using t = int8_t;
-};
-template <> struct DT<9> {
-    using t = uint16_t;
-};
+template <> struct DT<0> { using t = float; };
+template <> struct DT<1> { using t = uint32_t; };
+template <> struct DT<2> { using t = uint8_t; };
+template <> struct DT<3> { using t = int8_t; };
+template <> struct DT<4> { using t = uint16_t; };
+template <> struct DT<5> { using t = int16_t; };
+template <> struct DT<6> { using t = int32_t; };
+template <> struct DT<7> { using t = int64_t; };
+template <> struct DT<8> { using t = int8_t; };
+template <> struct DT<9> { using t = uint16_t; };
 
 } // namespace infini

--- a/include/core/data_type.h
+++ b/include/core/data_type.h
@@ -5,18 +5,30 @@ namespace infini {
 class DataType {
   public:
     // legacy
-    static const DataType Float32;
-    static const DataType UInt32;
     // These are just aligned with the type and index of onnx:
     // <https://onnx.ai/onnx/intro/concepts.html#element-type>
-    static const DataType UInt8, Int8, UInt16, Int16, Int32, Int64;
+    static const DataType Float32;
+    static const DataType UInt32;
+    static const DataType UInt8;
+    static const DataType Int8;
+    static const DataType UInt16;
+    static const DataType Int16;
+    static const DataType Int32;
+    static const DataType Int64;
+    static const DataType Bool;
+    static const DataType Float16;
     static constexpr size_t sizePerElement[]{
         sizeof(float),    sizeof(uint32_t), sizeof(uint8_t), sizeof(int8_t),
-        sizeof(uint16_t), sizeof(int16_t),  sizeof(int32_t), sizeof(int64_t)};
+        sizeof(uint16_t), sizeof(int16_t),  sizeof(int32_t), sizeof(int64_t),
+        sizeof(int8_t),   sizeof(uint8_t)};
 
-    static constexpr std::string_view names[]{"Float32", "UInt32", "UInt8",
-                                              "Int8",    "UInt16", "Int16",
-                                              "Int32",   "Int64"};
+    static constexpr std::string_view names[]{
+        "Float32", "UInt32", "UInt8", "Int8", "UInt16",
+        "Int16",   "Int32",  "Int64", "Bool", "Float16"};
+
+    static constexpr std::string_view sizetostring[]{
+        "float",   "uint32_t", "uint8_t", "int8_t", "uint16_t",
+        "int16_t", "int32_t",  "int64_t", "int8_t", "uint8_t"};
 
   private:
     int index;
@@ -29,37 +41,60 @@ class DataType {
     bool operator==(const DataType &rhs) const { return index == rhs.index; }
     bool operator<(const DataType &rhs) const { return index < rhs.index; }
 
-    template <typename T> static DataType get() {
+    template <typename T> static std::string get() {
         IT_TODO_HALT_MSG("Unsupported data type");
     }
     size_t getSize() const { return sizePerElement[index]; }
     string toString() const { return string(names[index]); }
+    string sizetoString() const { return string(sizetostring[index]); }
 };
 
 inline const DataType DataType::Float32(0);
 inline const DataType DataType::UInt32(1);
 inline const DataType DataType::UInt8(2), DataType::Int8(3),
     DataType::UInt16(4), DataType::Int16(5), DataType::Int32(6),
-    DataType::Int64(7);
+    DataType::Int64(7), DataType::Bool(8), DataType::Float16(9);
 // Method definitions are out of the declaration due to GCC bug:
 // https://stackoverflow.com/questions/49707184/explicit-specialization-in-non-namespace-scope-does-not-compile-in-gcc
-template <> inline DataType DataType::get<float>() { return Float32; }
-template <> inline DataType DataType::get<uint32_t>() { return UInt32; }
-template <> inline DataType DataType::get<uint8_t>() { return UInt8; }
-template <> inline DataType DataType::get<int8_t>() { return Int8; }
-template <> inline DataType DataType::get<uint16_t>() { return UInt16; }
-template <> inline DataType DataType::get<int16_t>() { return Int16; }
-template <> inline DataType DataType::get<int32_t>() { return Int32; }
-template <> inline DataType DataType::get<int64_t>() { return Int64; }
+template <> inline std::string DataType::get<float>() { return "float"; }
+template <> inline std::string DataType::get<uint32_t>() { return "uint32_t"; }
+template <> inline std::string DataType::get<uint8_t>() { return "uint8_t"; }
+template <> inline std::string DataType::get<int8_t>() { return "int8_t"; }
+template <> inline std::string DataType::get<uint16_t>() { return "uint16_t"; }
+template <> inline std::string DataType::get<int16_t>() { return "int16_t"; }
+template <> inline std::string DataType::get<int32_t>() { return "int32_t"; }
+template <> inline std::string DataType::get<int64_t>() { return "int64_t"; }
 
 template <int index> struct DT {};
-template <> struct DT<0> { using t = float; };
-template <> struct DT<1> { using t = uint32_t; };
-template <> struct DT<2> { using t = uint8_t; };
-template <> struct DT<3> { using t = int8_t; };
-template <> struct DT<4> { using t = uint16_t; };
-template <> struct DT<5> { using t = int16_t; };
-template <> struct DT<6> { using t = int32_t; };
-template <> struct DT<7> { using t = int64_t; };
+template <> struct DT<0> {
+    using t = float;
+};
+template <> struct DT<1> {
+    using t = uint32_t;
+};
+template <> struct DT<2> {
+    using t = uint8_t;
+};
+template <> struct DT<3> {
+    using t = int8_t;
+};
+template <> struct DT<4> {
+    using t = uint16_t;
+};
+template <> struct DT<5> {
+    using t = int16_t;
+};
+template <> struct DT<6> {
+    using t = int32_t;
+};
+template <> struct DT<7> {
+    using t = int64_t;
+};
+template <> struct DT<8> {
+    using t = int8_t;
+};
+template <> struct DT<9> {
+    using t = uint16_t;
+};
 
 } // namespace infini

--- a/include/core/data_type.h
+++ b/include/core/data_type.h
@@ -5,30 +5,43 @@ namespace infini {
 class DataType {
   public:
     // <https://onnx.ai/onnx/intro/concepts.html#element-type>
+    static const DataType Undefine;
     static const DataType Float32;
-    static const DataType UInt32;
     static const DataType UInt8;
     static const DataType Int8;
     static const DataType UInt16;
     static const DataType Int16;
     static const DataType Int32;
     static const DataType Int64;
+    static const DataType String;
     static const DataType Bool;
     static const DataType Float16;
+    static const DataType Double;
+    static const DataType UInt32;
+    static const DataType UInt64;
     // "sizePerElement" show the DType to cpu_type
-    // DataType::Bool -> int8_t   DataType::Float16 -> uint8_t
-    static constexpr size_t sizePerElement[]{
-        sizeof(float),    sizeof(uint32_t), sizeof(uint8_t), sizeof(int8_t),
-        sizeof(uint16_t), sizeof(int16_t),  sizeof(int32_t), sizeof(int64_t),
-        sizeof(int8_t),   sizeof(uint8_t)};
+    // DataType::Bool -> int8_t   DataType::Float16 -> uint16_t
+    static constexpr size_t sizePerElement[]{0,
+                                             sizeof(float),
+                                             sizeof(uint8_t),
+                                             sizeof(int8_t),
+                                             sizeof(uint16_t),
+                                             sizeof(int16_t),
+                                             sizeof(int32_t),
+                                             sizeof(int64_t),
+                                             sizeof(std::string),
+                                             sizeof(int8_t),
+                                             sizeof(uint16_t),
+                                             sizeof(double),
+                                             sizeof(uint32_t),
+                                             sizeof(uint64_t)};
 
     static constexpr std::string_view names[]{
-        "Float32", "UInt32", "UInt8", "Int8", "UInt16",
-        "Int16",   "Int32",  "Int64", "Bool", "Float16"};
+        "Undefine", "Float32", "UInt8",  "Int8",   "UInt16",
+        "Int16",    "Int32",   "Int64",  "String", "Bool",
+        "Float16",  "Double",  "UInt32", "UInt64"};
 
-    static constexpr std::string_view cpuType[]{
-        "float",   "uint32_t", "uint8_t", "int8_t", "uint16_t",
-        "int16_t", "int32_t",  "int64_t", "int8_t", "uint8_t"};
+    static constexpr int cpuType[]{-1, 0, 2, 3, 4, 5, 6, 7, -1, 3, 4, 9, 1, 8};
 
   private:
     int index;
@@ -41,40 +54,58 @@ class DataType {
     bool operator==(const DataType &rhs) const { return index == rhs.index; }
     bool operator<(const DataType &rhs) const { return index < rhs.index; }
 
-    template <typename T> static std::string get() {
+    template <typename T> static int get() {
         IT_TODO_HALT_MSG("Unsupported data type");
     }
     size_t getSize() const { return sizePerElement[index]; }
     string toString() const { return string(names[index]); }
-    string cpuTypeString() const { return string(cpuType[index]); }
+    int cpuTypeInt() const { return cpuType[index]; }
+    int getIndex() const { return index; }
 };
 
-inline const DataType DataType::Float32(0);
-inline const DataType DataType::UInt32(1);
-inline const DataType DataType::UInt8(2), DataType::Int8(3),
-    DataType::UInt16(4), DataType::Int16(5), DataType::Int32(6),
-    DataType::Int64(7), DataType::Bool(8), DataType::Float16(9);
+// to be consistent with onnx
+// https://github.com/onnx/onnx/blob/aeb21329122b96df1d3ef33b500a35ca140b1431/onnx/onnx.proto#L484
+inline const DataType DataType::Undefine(0);
+inline const DataType DataType::Float32(1);
+inline const DataType DataType::UInt8(2);
+inline const DataType DataType::Int8(3);
+inline const DataType DataType::UInt16(4);
+inline const DataType DataType::Int16(5);
+inline const DataType DataType::Int32(6);
+inline const DataType DataType::Int64(7);
+inline const DataType DataType::String(8);
+inline const DataType DataType::Bool(9);
+inline const DataType DataType::Float16(10);
+inline const DataType DataType::Double(11);
+inline const DataType DataType::UInt32(12);
+inline const DataType DataType::UInt64(13);
 // Method definitions are out of the declaration due to GCC bug:
 // https://stackoverflow.com/questions/49707184/explicit-specialization-in-non-namespace-scope-does-not-compile-in-gcc
-template <> inline std::string DataType::get<float>() { return "float"; }
-template <> inline std::string DataType::get<uint32_t>() { return "uint32_t"; }
-template <> inline std::string DataType::get<uint8_t>() { return "uint8_t"; }
-template <> inline std::string DataType::get<int8_t>() { return "int8_t"; }
-template <> inline std::string DataType::get<uint16_t>() { return "uint16_t"; }
-template <> inline std::string DataType::get<int16_t>() { return "int16_t"; }
-template <> inline std::string DataType::get<int32_t>() { return "int32_t"; }
-template <> inline std::string DataType::get<int64_t>() { return "int64_t"; }
+template <> inline int DataType::get<float>() { return 0; }
+template <> inline int DataType::get<uint32_t>() { return 1; }
+template <> inline int DataType::get<uint8_t>() { return 2; }
+template <> inline int DataType::get<int8_t>() { return 3; }
+template <> inline int DataType::get<uint16_t>() { return 4; }
+template <> inline int DataType::get<int16_t>() { return 5; }
+template <> inline int DataType::get<int32_t>() { return 6; }
+template <> inline int DataType::get<int64_t>() { return 7; }
+template <> inline int DataType::get<uint64_t>() { return 8; }
+template <> inline int DataType::get<double>() { return 9; }
 
 template <int index> struct DT {};
-template <> struct DT<0> { using t = float; };
-template <> struct DT<1> { using t = uint32_t; };
+template <> struct DT<0> { using t = bool; };
+template <> struct DT<1> { using t = float; };
 template <> struct DT<2> { using t = uint8_t; };
 template <> struct DT<3> { using t = int8_t; };
 template <> struct DT<4> { using t = uint16_t; };
 template <> struct DT<5> { using t = int16_t; };
 template <> struct DT<6> { using t = int32_t; };
 template <> struct DT<7> { using t = int64_t; };
-template <> struct DT<8> { using t = int8_t; };
-template <> struct DT<9> { using t = uint16_t; };
+template <> struct DT<8> { using t = char; };
+template <> struct DT<9> { using t = int8_t; };
+template <> struct DT<10> { using t = uint16_t; };
+template <> struct DT<11> { using t = double; };
+template <> struct DT<12> { using t = uint32_t; };
+template <> struct DT<13> { using t = uint64_t; };
 
 } // namespace infini

--- a/include/core/graph_handler.h
+++ b/include/core/graph_handler.h
@@ -7,30 +7,6 @@
 
 namespace infini {
 
-// Use the indices from onnx to reduce delivery overhead,
-// which comes from onnx but may be not only used for onnx.
-//
-// see https://onnx.ai/onnx/intro/concepts.html#element-type
-enum OnnxDType : int {
-    UNDEFINED = 0,
-    FLOAT,
-    UINT8,
-    INT8,
-    UINT16,
-    INT16,
-    INT32,
-    INT64,
-    STRING,
-    BOOL,
-    FLOAT16,
-    DOUBLE,
-    UINT32,
-    UINT64,
-    COMPLEX64,
-    COMPLEX128,
-    BFLOAT16,
-};
-
 class GraphHandlerObj {
     Graph g;
 

--- a/include/core/tensor.h
+++ b/include/core/tensor.h
@@ -32,10 +32,7 @@ class TensorObj : public TensorBaseObj {
     string toString() const override;
 
     size_t size() const { return _size; }
-    size_t getBytes() const {
-        size_t usebytes = _size * dtype.getSize();
-        return dtype == DataType::Float16 ? usebytes * 2 : usebytes;
-    }
+    size_t getBytes() const { return _size * dtype.getSize(); }
 
     Shape getDims() const { return shape; }
     vector<size_t> getStride() const;
@@ -48,24 +45,20 @@ class TensorObj : public TensorBaseObj {
 
     // Copy elements from `data`.
     template <typename T> void copyin(const vector<T> &data) {
-        IT_ASSERT(DataType::get<T>() == dtype.cpuTypeString());
+        IT_ASSERT(DataType::get<T>() == dtype.cpuTypeInt());
         IT_ASSERT(data.size() >= _size);
         copyin(data.data(), getBytes());
     }
     // Copy all the elements to a vector.
     template <typename T> auto copyout() const {
-        IT_ASSERT(DataType::get<T>() == dtype.cpuTypeString());
-        auto sizeofvec = _size;
-        if (dtype == DataType::Float16) {
-            sizeofvec = _size * 2;
-        }
-        std::vector<T> ans(sizeofvec);
+        IT_ASSERT(DataType::get<T>() == dtype.cpuTypeInt());
+        std::vector<T> ans(_size);
         copyout(ans.data(), getBytes());
         return ans;
     }
     // Copy the element at `pos`.
     template <typename T> auto copyOne(const vector<int> &pos) const {
-        IT_ASSERT(DataType::get<T>() == dtype.cpuTypeString());
+        IT_ASSERT(DataType::get<T>() == dtype.cpuTypeInt());
         auto offset = getOffset(pos);
         auto bytes = dtype.getSize();
         T ans;
@@ -105,7 +98,7 @@ class TensorObj : public TensorBaseObj {
     bool equalData(const Tensor &rhs, double relativeError = 1e-6) const;
 
     template <typename T> bool equalData(const vector<T> &dataVector) {
-        IT_ASSERT(DataType::get<T>() == dtype.cpuTypeString());
+        IT_ASSERT(DataType::get<T>() == dtype.cpuTypeInt());
         IT_ASSERT(size() == dataVector.size());
         return equalDataImpl(getRawDataPtr<T *>(), dataVector.data(), size());
     }

--- a/include/core/tensor.h
+++ b/include/core/tensor.h
@@ -48,13 +48,13 @@ class TensorObj : public TensorBaseObj {
 
     // Copy elements from `data`.
     template <typename T> void copyin(const vector<T> &data) {
-        IT_ASSERT(DataType::get<T>() == dtype.sizetoString());
+        IT_ASSERT(DataType::get<T>() == dtype.cpuTypeString());
         IT_ASSERT(data.size() >= _size);
         copyin(data.data(), getBytes());
     }
     // Copy all the elements to a vector.
     template <typename T> auto copyout() const {
-        IT_ASSERT(DataType::get<T>() == dtype.sizetoString());
+        IT_ASSERT(DataType::get<T>() == dtype.cpuTypeString());
         auto sizeofvec = _size;
         if (dtype == DataType::Float16) {
             sizeofvec = _size * 2;
@@ -65,7 +65,7 @@ class TensorObj : public TensorBaseObj {
     }
     // Copy the element at `pos`.
     template <typename T> auto copyOne(const vector<int> &pos) const {
-        IT_ASSERT(DataType::get<T>() == dtype.sizetoString());
+        IT_ASSERT(DataType::get<T>() == dtype.cpuTypeString());
         auto offset = getOffset(pos);
         auto bytes = dtype.getSize();
         T ans;
@@ -105,7 +105,7 @@ class TensorObj : public TensorBaseObj {
     bool equalData(const Tensor &rhs, double relativeError = 1e-6) const;
 
     template <typename T> bool equalData(const vector<T> &dataVector) {
-        IT_ASSERT(DataType::get<T>() == dtype.sizetoString());
+        IT_ASSERT(DataType::get<T>() == dtype.cpuTypeString());
         IT_ASSERT(size() == dataVector.size());
         return equalDataImpl(getRawDataPtr<T *>(), dataVector.data(), size());
     }

--- a/include/operators/reshape.h
+++ b/include/operators/reshape.h
@@ -60,6 +60,7 @@ class FlattenObj : public OperatorObj {
     std::string toString() const override;
     int numInputs() const override { return 1; }
     int numOutputs() const override { return 1; }
+    int getAxis() const { return axis; }
 
   private:
     vector<int> getWorkloadVector() const override;

--- a/include/utils/data_convert.h
+++ b/include/utils/data_convert.h
@@ -1,0 +1,11 @@
+#pragma once
+#include <iostream>
+
+namespace infini {
+union Uf32 {
+    float f32;
+    uint32_t u32;
+};
+uint16_t float_to_fp16(const float x);
+float fp16_to_float(const uint16_t x);
+} // namespace infini

--- a/include/utils/data_generator.h
+++ b/include/utils/data_generator.h
@@ -1,6 +1,7 @@
 #pragma once
 #include "core/common.h"
 #include "core/tensor_base.h"
+#include "utils/data_convert.h"
 #include <random>
 
 namespace infini {
@@ -10,6 +11,7 @@ class DataGenerator {
   private:
     virtual void fill(uint32_t *data, size_t size) { IT_TODO_HALT(); }
     virtual void fill(float *data, size_t size) { IT_TODO_HALT(); }
+    virtual void fill_fp16(uint16_t *data, size_t size) { IT_TODO_HALT(); }
 
   public:
     virtual ~DataGenerator() {}
@@ -18,6 +20,8 @@ class DataGenerator {
             fill(reinterpret_cast<uint32_t *>(data), size);
         else if (dataType == DataType::Float32)
             fill(reinterpret_cast<float *>(data), size);
+        else if (dataType == DataType::Float16)
+            fill_fp16(reinterpret_cast<uint16_t *>(data), size);
         else
             IT_TODO_HALT();
     }
@@ -38,6 +42,13 @@ class IncrementalGenerator : public DataGenerator {
         fill<uint32_t>(data, size);
     }
     void fill(float *data, size_t size) override { fill<float>(data, size); }
+    // FIXME: fix the accuracy standards when dtype is float16
+    void fill_fp16(uint16_t *data, size_t size) {
+        for (size_t i = 0; i < size; i++) {
+            float x = 2.0f;
+            data[i] = float_to_fp16(x);
+        }
+    }
 };
 
 class RandomGenerator : public DataGenerator {

--- a/pyinfinitensor/src/pyinfinitensor/onnx.py
+++ b/pyinfinitensor/src/pyinfinitensor/onnx.py
@@ -536,9 +536,10 @@ class OnnxStub:
                 elif tensor.data_type == TensorProto.FLOAT16:
                     if len(tensor.int32_data) != 0:
                         list_int32_data = []
-                        for i in tensor.int32_data:
-                            list_int32_data.append(i.to_bytes(2, "little")[0])
-                            list_int32_data.append(i.to_bytes(2, "little")[1])
+                        for element_data in tensor.int32_data:
+                            element_byte = element_data.to_bytes(2, "little")
+                            list_int32_data.append(element_byte[0])
+                            list_int32_data.append(element_byte[1])
                         obj.copyin_uint8(list_int32_data)
                     elif len(tensor.raw_data) != 0:
                         obj.copyin_uint8(list(tensor.raw_data))

--- a/pyinfinitensor/src/pyinfinitensor/onnx.py
+++ b/pyinfinitensor/src/pyinfinitensor/onnx.py
@@ -1,5 +1,4 @@
 ﻿import backend
-import struct
 from onnx import (
     ModelProto,
     TensorProto,

--- a/pyinfinitensor/tests/test_onnx.py
+++ b/pyinfinitensor/tests/test_onnx.py
@@ -64,6 +64,21 @@ class TestStringMethods(unittest.TestCase):
         )
         make_and_import_model(make_graph([conv], "conv", [i, w], [o]))
 
+    def test_conv_fp16(self):
+        i = make_tensor_value_info("i", TensorProto.FLOAT16, [1, 3, 4, 4])
+        w = make_tensor_value_info("w", TensorProto.FLOAT16, [2, 3, 3, 3])
+        o = make_tensor_value_info("o", TensorProto.FLOAT16, [1, 2, 2, 2])
+        conv = make_node(
+            "Conv",
+            ["i", "w"],
+            ["o"],
+            "conv",
+            pads=[1, 1, 1, 1],
+            strides=[2, 1],
+            dilations=[1, 2],
+        )
+        make_and_import_model(make_graph([conv], "conv_fp16", [i, w], [o]))
+
     def test_matmul(self):
         x = make_tensor_value_info("x", TensorProto.FLOAT, [1, 2, 3])
         a = make_tensor_value_info("a", TensorProto.FLOAT, [1, 3, 4])
@@ -211,9 +226,9 @@ class TestStringMethods(unittest.TestCase):
         x = make_tensor_value_info("x", TensorProto.FLOAT, [1, 3, 5, 7])
         y = make_tensor_value_info("y", TensorProto.FLOAT, [1 * 3, 5 * 7])
         flatten = make_node("Flatten", ["x"], ["y"], axis=2, name="flatten")
-        # make_and_import_model(
-        make_graph([flatten], "flatten", [x], [y])
-        # )
+        make_and_import_model(
+            make_graph([flatten], "flatten", [x], [y])
+        )
 
     def test_reshape(self):
         data = make_tensor_value_info("data", TensorProto.FLOAT, [2, 3, 4, 5])

--- a/src/bang/bang_runtime.cc
+++ b/src/bang/bang_runtime.cc
@@ -14,7 +14,7 @@ void BangRuntimeObj::runWithoutSync(const Graph &graph, bool tune = false,
     for (auto &op : graph->getOperators()) {
         // HACK: set correct data type
         auto kernelAttrs =
-            KernelAttrs{device, op->getOpType(), DataType::Float32};
+            KernelAttrs{device, op->getOpType(), op->getDType()};
         Kernel *kernel = kernelRegistry.getKernel(kernelAttrs);
         auto perfKey = PerfEngine::Key{kernelAttrs, op->getOpPerfKey()};
         auto perfData = perfEngine.getPerfData(perfKey);

--- a/src/bang/bang_runtime.cc
+++ b/src/bang/bang_runtime.cc
@@ -13,8 +13,7 @@ void BangRuntimeObj::runWithoutSync(const Graph &graph, bool tune = false,
     std::map<OpType, int> opCnt;
     for (auto &op : graph->getOperators()) {
         // HACK: set correct data type
-        auto kernelAttrs =
-            KernelAttrs{device, op->getOpType(), op->getDType()};
+        auto kernelAttrs = KernelAttrs{device, op->getOpType(), op->getDType()};
         Kernel *kernel = kernelRegistry.getKernel(kernelAttrs);
         auto perfKey = PerfEngine::Key{kernelAttrs, op->getOpPerfKey()};
         auto perfData = perfEngine.getPerfData(perfKey);

--- a/src/core/graph_handler.cc
+++ b/src/core/graph_handler.cc
@@ -309,6 +309,10 @@ static DataType dtype_repr_convert(int dtype) {
         return DataType::Int32;
     case OnnxDType::INT64:
         return DataType::Int64;
+    case OnnxDType::BOOL:
+        return DataType::Bool;
+    case OnnxDType::FLOAT16:
+        return DataType::Float16;
     default:
         IT_ASSERT(false, "Unsupported data type");
     }

--- a/src/core/graph_handler.cc
+++ b/src/core/graph_handler.cc
@@ -292,27 +292,35 @@ Tensor GraphHandlerObj::pad(Tensor input, Tensor output,
 }
 
 static DataType dtype_repr_convert(int dtype) {
-    switch ((OnnxDType)dtype) {
-    case OnnxDType::FLOAT:
+    switch (dtype) {
+    case 0:
+        return DataType::Undefine;
+    case 1:
         return DataType::Float32;
-    case OnnxDType::UINT32:
-        return DataType::UInt32;
-    case OnnxDType::UINT8:
+    case 2:
         return DataType::UInt8;
-    case OnnxDType::INT8:
+    case 3:
         return DataType::Int8;
-    case OnnxDType::UINT16:
+    case 4:
         return DataType::UInt16;
-    case OnnxDType::INT16:
+    case 5:
         return DataType::Int16;
-    case OnnxDType::INT32:
+    case 6:
         return DataType::Int32;
-    case OnnxDType::INT64:
+    case 7:
         return DataType::Int64;
-    case OnnxDType::BOOL:
+    case 8:
+        return DataType::String;
+    case 9:
         return DataType::Bool;
-    case OnnxDType::FLOAT16:
+    case 10:
         return DataType::Float16;
+    case 11:
+        return DataType::Double;
+    case 12:
+        return DataType::UInt32;
+    case 13:
+        return DataType::UInt64;
     default:
         IT_ASSERT(false, "Unsupported data type");
     }

--- a/src/core/operator.cc
+++ b/src/core/operator.cc
@@ -110,8 +110,6 @@ optional<vector<Shape>> OperatorObj::inferShape() const {
 
 vector<DataType> OperatorObj::inferDataType(const TensorVec &inputs) const {
     auto dataType = inputs[0]->getDType();
-    for (const auto &tensor : inputs)
-        IT_ASSERT(dataType == tensor->getDType());
     return vector(numOutputs(), dataType);
 }
 

--- a/src/core/perf_engine.cc
+++ b/src/core/perf_engine.cc
@@ -30,9 +30,7 @@ void from_json(const json &j, OpPerfKey &p) {
     j.at("opType").get_to(p.opType);
     j.at("attrs").get_to(p.attrs);
 }
-void to_json(json &j, const DataType &p) {
-    j = p.toString() == "Float32" ? 0 : 1;
-}
+void to_json(json &j, const DataType &p) { j = p.getIndex(); }
 void from_json(const json &j, DataType &p) { p = DataType(j.get<int>()); }
 void to_json(json &j, const PerfRecord &p) { p->to_json(j); }
 void from_json(const json &j, PerfRecord &p) {

--- a/src/core/tensor.cc
+++ b/src/core/tensor.cc
@@ -71,14 +71,20 @@ void TensorObj::printData() const {
     if (dtype == DataType(N))                                                  \
         std::cout << dataToString<DT<N>::t>() << std::endl;
 
-    TRY_PRINT(0)          // fmt: new line
-    else TRY_PRINT(1)     //
-        else TRY_PRINT(2) //
-        else TRY_PRINT(3) //
-        else TRY_PRINT(4) //
-        else TRY_PRINT(5) //
-        else TRY_PRINT(6) //
-        else TRY_PRINT(7) //
+    TRY_PRINT(0)           // fmt: new line
+    else TRY_PRINT(1)      //
+        else TRY_PRINT(2)  //
+        else TRY_PRINT(3)  //
+        else TRY_PRINT(4)  //
+        else TRY_PRINT(5)  //
+        else TRY_PRINT(6)  //
+        else TRY_PRINT(7)  //
+        else TRY_PRINT(8)  //
+        else TRY_PRINT(9)  //
+        else TRY_PRINT(10) //
+        else TRY_PRINT(11) //
+        else TRY_PRINT(12) //
+        else TRY_PRINT(13) //
         else IT_TODO_HALT();
 
 #undef TRY_PRINT
@@ -98,14 +104,20 @@ bool TensorObj::equalData(const Tensor &rhs, double relativeError) const {
         return equalDataImpl(getRawDataPtr<DT<N>::t *>(),                      \
                              rhs->getRawDataPtr<DT<N>::t *>(), size());
 
-    TEST_EQUAL(0)          // fmt: new line
-    else TEST_EQUAL(1)     //
-        else TEST_EQUAL(2) //
-        else TEST_EQUAL(3) //
-        else TEST_EQUAL(4) //
-        else TEST_EQUAL(5) //
-        else TEST_EQUAL(6) //
-        else TEST_EQUAL(7) //
+    TEST_EQUAL(0)           // fmt: new line
+    else TEST_EQUAL(1)      //
+        else TEST_EQUAL(2)  //
+        else TEST_EQUAL(3)  //
+        else TEST_EQUAL(4)  //
+        else TEST_EQUAL(5)  //
+        else TEST_EQUAL(6)  //
+        else TEST_EQUAL(7)  //
+        else TEST_EQUAL(8)  //
+        else TEST_EQUAL(9)  //
+        else TEST_EQUAL(10) //
+        else TEST_EQUAL(11) //
+        else TEST_EQUAL(12) //
+        else TEST_EQUAL(13) //
         else IT_TODO_HALT();
 
 #undef TEST_EQUAL

--- a/src/cuda/cuda_runtime.cc
+++ b/src/cuda/cuda_runtime.cc
@@ -11,8 +11,7 @@ void CudaRuntimeObj::runWithoutSync(const Graph &graph) const {
     auto &perfEngine = PerfEngine::getInstance();
     for (auto &op : graph->getOperators()) {
         // HACK: set correct data type
-        auto kernelAttrs =
-            KernelAttrs{device, op->getOpType(), op->getDType()};
+        auto kernelAttrs = KernelAttrs{device, op->getOpType(), op->getDType()};
         Kernel *kernel = kernelRegistry.getKernel(kernelAttrs);
         auto perfKey = PerfEngine::Key{kernelAttrs, op->getOpPerfKey()};
         auto perfData = perfEngine.getPerfData(perfKey);
@@ -33,8 +32,7 @@ void CudaRuntimeObj::tune(const Graph &graph, bool profiling = false) const {
     std::map<OpType, int> opCnt;
     for (auto &op : graph->getOperators()) {
         // HACK: set correct data type
-        auto kernelAttrs =
-            KernelAttrs{device, op->getOpType(), op->getDType()};
+        auto kernelAttrs = KernelAttrs{device, op->getOpType(), op->getDType()};
         Kernel *kernel = kernelRegistry.getKernel(kernelAttrs);
         auto perfKey = PerfEngine::Key{kernelAttrs, op->getOpPerfKey()};
         auto perfData = perfEngine.getPerfData(perfKey);

--- a/src/cuda/cuda_runtime.cc
+++ b/src/cuda/cuda_runtime.cc
@@ -12,7 +12,7 @@ void CudaRuntimeObj::runWithoutSync(const Graph &graph) const {
     for (auto &op : graph->getOperators()) {
         // HACK: set correct data type
         auto kernelAttrs =
-            KernelAttrs{device, op->getOpType(), DataType::Float32};
+            KernelAttrs{device, op->getOpType(), op->getDType()};
         Kernel *kernel = kernelRegistry.getKernel(kernelAttrs);
         auto perfKey = PerfEngine::Key{kernelAttrs, op->getOpPerfKey()};
         auto perfData = perfEngine.getPerfData(perfKey);
@@ -34,7 +34,7 @@ void CudaRuntimeObj::tune(const Graph &graph, bool profiling = false) const {
     for (auto &op : graph->getOperators()) {
         // HACK: set correct data type
         auto kernelAttrs =
-            KernelAttrs{device, op->getOpType(), DataType::Float32};
+            KernelAttrs{device, op->getOpType(), op->getDType()};
         Kernel *kernel = kernelRegistry.getKernel(kernelAttrs);
         auto perfKey = PerfEngine::Key{kernelAttrs, op->getOpPerfKey()};
         auto perfData = perfEngine.getPerfData(perfKey);

--- a/src/ffi/ffi_infinitensor.cc
+++ b/src/ffi/ffi_infinitensor.cc
@@ -116,6 +116,10 @@ static int tensor_dtype(Tensor t) {
         return OnnxDType::INT32;
     if (t->getDType() == DataType::Int64)
         return OnnxDType::INT64;
+    if (t->getDType() == DataType::Bool)
+        return OnnxDType::BOOL;
+    if (t->getDType() == DataType::Float16)
+        return OnnxDType::FLOAT16;
     IT_ASSERT(false, "Unsupported data type");
 }
 
@@ -224,6 +228,11 @@ static vector<int> transpose_permute_of(Operator op) {
     return dynamic_cast<const TransposeObj *>(op.get())->getPermute();
 }
 
+static int flatten_axis_of(Operator op) {
+    IT_ASSERT(op->getOpType() == OpType::Flatten);
+    return dynamic_cast<const FlattenObj *>(op.get())->getAxis();
+}
+
 void export_functions(py::module &m) {
 #define FUNCTION(NAME) def(#NAME, &NAME)
     m.def("cpu_runtime", &NativeCpuRuntimeObj::getInstance)
@@ -252,7 +261,8 @@ void export_functions(py::module &m) {
         .FUNCTION(transpose_permute_of)
         .FUNCTION(concat_axis_of)
         .FUNCTION(split_axis_of)
-        .FUNCTION(gather_axis_of);
+        .FUNCTION(gather_axis_of)
+        .FUNCTION(flatten_axis_of);
 #undef FUNCTION
 }
 
@@ -276,6 +286,8 @@ void init_graph_builder(py::module &m) {
         .def("copyin_float", &TensorObj::copyin<float>, policy::move)
         .def("copyin_int32", &TensorObj::copyin<int32_t>, policy::move)
         .def("copyin_int64", &TensorObj::copyin<int64_t>, policy::move)
+        .def("copyin_int8", &TensorObj::copyin<int8_t>, policy::move)
+        .def("copyin_uint8", &TensorObj::copyin<uint8_t>, policy::move)
         .def("copyout_float", &TensorObj::copyout<float>, policy::move)
         .def("copyout_int32", &TensorObj::copyout<int32_t>, policy::move)
         .def("copyout_int64", &TensorObj::copyout<int64_t>, policy::move)

--- a/src/ffi/ffi_infinitensor.cc
+++ b/src/ffi/ffi_infinitensor.cc
@@ -100,26 +100,34 @@ void export_values(py::module &m) {
 }
 
 static int tensor_dtype(Tensor t) {
+    if (t->getDType() == DataType::Undefine)
+        return 0;
     if (t->getDType() == DataType::Float32)
-        return OnnxDType::FLOAT;
-    if (t->getDType() == DataType::UInt32)
-        return OnnxDType::UINT32;
+        return 1;
     if (t->getDType() == DataType::UInt8)
-        return OnnxDType::UINT8;
+        return 2;
     if (t->getDType() == DataType::Int8)
-        return OnnxDType::INT8;
+        return 3;
     if (t->getDType() == DataType::UInt16)
-        return OnnxDType::UINT16;
+        return 4;
     if (t->getDType() == DataType::Int16)
-        return OnnxDType::INT16;
+        return 5;
     if (t->getDType() == DataType::Int32)
-        return OnnxDType::INT32;
+        return 6;
     if (t->getDType() == DataType::Int64)
-        return OnnxDType::INT64;
+        return 7;
+    if (t->getDType() == DataType::String)
+        return 8;
     if (t->getDType() == DataType::Bool)
-        return OnnxDType::BOOL;
+        return 9;
     if (t->getDType() == DataType::Float16)
-        return OnnxDType::FLOAT16;
+        return 10;
+    if (t->getDType() == DataType::Double)
+        return 11;
+    if (t->getDType() == DataType::UInt32)
+        return 12;
+    if (t->getDType() == DataType::UInt64)
+        return 13;
     IT_ASSERT(false, "Unsupported data type");
 }
 
@@ -288,9 +296,13 @@ void init_graph_builder(py::module &m) {
         .def("copyin_int64", &TensorObj::copyin<int64_t>, policy::move)
         .def("copyin_int8", &TensorObj::copyin<int8_t>, policy::move)
         .def("copyin_uint8", &TensorObj::copyin<uint8_t>, policy::move)
+        .def("copyin_float16", &TensorObj::copyin<uint16_t>, policy::move)
         .def("copyout_float", &TensorObj::copyout<float>, policy::move)
         .def("copyout_int32", &TensorObj::copyout<int32_t>, policy::move)
         .def("copyout_int64", &TensorObj::copyout<int64_t>, policy::move)
+        .def("copyout_int8", &TensorObj::copyout<int8_t>, policy::move)
+        .def("copyout_uint8", &TensorObj::copyout<uint8_t>, policy::move)
+        .def("copyout_float16", &TensorObj::copyout<uint16_t>, policy::move)
         .def("has_target", &TensorObj::hasTarget, policy::automatic)
         .def("src", &TensorObj::getSource, policy::move)
         .def("printData", &TensorObj::printData, policy::automatic);

--- a/src/kernels/cuda/conv_half.cc
+++ b/src/kernels/cuda/conv_half.cc
@@ -33,7 +33,7 @@ struct ConvCuDnnPerfRecordObj : public PerfRecordObj {
 
 using ConvCuDnnPerfRecord = Ref<ConvCuDnnPerfRecordObj>;
 
-class convCudnnHalf : public Kernel {
+class convCudnnFP16 : public Kernel {
 
     static constexpr int N_ALGO = 8;
     static constexpr int N_MODE = 2;
@@ -294,7 +294,7 @@ class convCudnnHalf : public Kernel {
     }
 };
 
-REGISTER_KERNEL(Device::CUDA, OpType::Conv, DataType::Float16, convCudnnHalf,
+REGISTER_KERNEL(Device::CUDA, OpType::Conv, DataType::Float16, convCudnnFP16,
                 "Conv_cuDNN_CUDA_Float16");
 
 REGISTER_CONSTRUCTOR(1, ConvCuDnnPerfRecordObj::from_json);

--- a/src/kernels/cuda/conv_half.cc
+++ b/src/kernels/cuda/conv_half.cc
@@ -1,11 +1,10 @@
-#include "operators/conv.h"
 #include "core/kernel.h"
 #include "cuda/cuda_runtime.h"
+#include "operators/conv.h"
 #include <chrono>
 #include <functional>
 #include <limits>
 #include <tuple>
-
 
 namespace infini {
 
@@ -73,20 +72,22 @@ class convCudnnFP16 : public Kernel {
         // get inputs
         cudnnTensorDescriptor_t inDesc;
         checkCudnnError(cudnnCreateTensorDescriptor(&inDesc));
-        checkCudnnError(cudnnSetTensor4dDescriptor(
-            inDesc, CUDNN_TENSOR_NCHW, CUDNN_DATA_HALF, n, channels, h, w)); /*fp16 type*/
+        checkCudnnError(cudnnSetTensor4dDescriptor(inDesc, CUDNN_TENSOR_NCHW,
+                                                   CUDNN_DATA_HALF, n, channels,
+                                                   h, w)); /*fp16 type*/
 
         // get kernels
         cudnnFilterDescriptor_t knDesc;
         checkCudnnError(cudnnCreateFilterDescriptor(&knDesc));
-        checkCudnnError(cudnnSetFilter4dDescriptor(knDesc, CUDNN_DATA_HALF, /*fp16 type*/
-                                                   CUDNN_TENSOR_NCHW, f,
-                                                   channelsPerGrp, r, s));
+        checkCudnnError(cudnnSetFilter4dDescriptor(
+            knDesc, CUDNN_DATA_HALF, /*fp16 type*/
+            CUDNN_TENSOR_NCHW, f, channelsPerGrp, r, s));
         // get bias
         cudnnTensorDescriptor_t biasDesc;
         checkCudnnError(cudnnCreateTensorDescriptor(&biasDesc));
-        checkCudnnError(cudnnSetTensor4dDescriptor(
-            biasDesc, CUDNN_TENSOR_NCHW, CUDNN_DATA_HALF, 1, f, 1, 1)); /*fp16 type*/
+        checkCudnnError(cudnnSetTensor4dDescriptor(biasDesc, CUDNN_TENSOR_NCHW,
+                                                   CUDNN_DATA_HALF, 1, f, 1,
+                                                   1)); /*fp16 type*/
 
         // get convolution descriptor
         cudnnConvolutionDescriptor_t convDesc;
@@ -297,5 +298,4 @@ class convCudnnFP16 : public Kernel {
 REGISTER_KERNEL(Device::CUDA, OpType::Conv, DataType::Float16, convCudnnFP16,
                 "Conv_cuDNN_CUDA_Float16");
 
-REGISTER_CONSTRUCTOR(1, ConvCuDnnPerfRecordObj::from_json);
 } // namespace infini

--- a/src/kernels/cuda/conv_half.cc
+++ b/src/kernels/cuda/conv_half.cc
@@ -1,0 +1,301 @@
+#include "operators/conv.h"
+#include "core/kernel.h"
+#include "cuda/cuda_runtime.h"
+#include <chrono>
+#include <functional>
+#include <limits>
+#include <tuple>
+
+
+namespace infini {
+
+struct ConvCuDnnPerfRecordObj : public PerfRecordObj {
+    int algo = 0; // cudnnConvolutionFwdAlgo_t
+    int mode = 1;
+    size_t workspaceSize = 100000;
+    bool fuseAct = false;
+    void to_json(json &j) override {
+        j["type"] = 1;
+        j["data"] = std::make_tuple(algo, mode, fuseAct, time, workspaceSize);
+    }
+    static PerfRecord from_json(const json &j) {
+        ConvCuDnnPerfRecordObj tmp;
+        auto [Algo, Mode, FuseAct, Time, WorkspaceSize] =
+            j["data"].get<tuple<int, int, bool, double, size_t>>();
+        tmp.algo = Algo;
+        tmp.mode = Mode;
+        tmp.fuseAct = FuseAct;
+        tmp.time = Time;
+        tmp.workspaceSize = WorkspaceSize;
+        return make_ref<ConvCuDnnPerfRecordObj>(tmp);
+    }
+};
+
+using ConvCuDnnPerfRecord = Ref<ConvCuDnnPerfRecordObj>;
+
+class convCudnnHalf : public Kernel {
+
+    static constexpr int N_ALGO = 8;
+    static constexpr int N_MODE = 2;
+    static constexpr cudnnConvolutionFwdAlgo_t ALGOS[8] = {
+        CUDNN_CONVOLUTION_FWD_ALGO_IMPLICIT_GEMM,
+        CUDNN_CONVOLUTION_FWD_ALGO_IMPLICIT_PRECOMP_GEMM,
+        CUDNN_CONVOLUTION_FWD_ALGO_GEMM,
+        CUDNN_CONVOLUTION_FWD_ALGO_DIRECT,
+        CUDNN_CONVOLUTION_FWD_ALGO_FFT,
+        CUDNN_CONVOLUTION_FWD_ALGO_FFT_TILING,
+        CUDNN_CONVOLUTION_FWD_ALGO_WINOGRAD,
+        CUDNN_CONVOLUTION_FWD_ALGO_WINOGRAD_NONFUSED};
+
+    static constexpr cudnnConvolutionMode_t MODES[2] = {
+        CUDNN_CONVOLUTION, CUDNN_CROSS_CORRELATION};
+
+    std::tuple<void *, void *, void *, cudnnTensorDescriptor_t,
+               cudnnFilterDescriptor_t, cudnnTensorDescriptor_t,
+               cudnnConvolutionDescriptor_t, cudnnActivationDescriptor_t,
+               cudnnTensorDescriptor_t>
+    createCuDNNDescriptor(const Ref<ConvObj> &op,
+                          const ConvCuDnnPerfRecord &record) const {
+        void *const inData = (op->getInputs(0)->getRawDataPtr<void *>());
+        void *const knData = (op->getInputs(1)->getRawDataPtr<void *>());
+        if (op->getInputs().size() > 2) // Bias is not supported yet
+            IT_TODO_HALT();
+        // void *const biasData = (op->getInputs(2)->getRawDataPtr<void *>());
+        void *const outData = (op->getOutput()->getRawDataPtr<void *>());
+
+        const auto [n, c, h, w, f, r, s] = op->getNCHWFRS();
+        const int cpg = op->getChannelPerGroup();
+        const int g = c / cpg;
+        const auto [ph, pw, sh, sw, dh, dw] = op->getPadStrideDilation();
+
+        int channelsPerGrp = cpg, channels = c;
+
+        // get inputs
+        cudnnTensorDescriptor_t inDesc;
+        checkCudnnError(cudnnCreateTensorDescriptor(&inDesc));
+        checkCudnnError(cudnnSetTensor4dDescriptor(
+            inDesc, CUDNN_TENSOR_NCHW, CUDNN_DATA_HALF, n, channels, h, w)); /*fp16 type*/
+
+        // get kernels
+        cudnnFilterDescriptor_t knDesc;
+        checkCudnnError(cudnnCreateFilterDescriptor(&knDesc));
+        checkCudnnError(cudnnSetFilter4dDescriptor(knDesc, CUDNN_DATA_HALF, /*fp16 type*/
+                                                   CUDNN_TENSOR_NCHW, f,
+                                                   channelsPerGrp, r, s));
+        // get bias
+        cudnnTensorDescriptor_t biasDesc;
+        checkCudnnError(cudnnCreateTensorDescriptor(&biasDesc));
+        checkCudnnError(cudnnSetTensor4dDescriptor(
+            biasDesc, CUDNN_TENSOR_NCHW, CUDNN_DATA_HALF, 1, f, 1, 1)); /*fp16 type*/
+
+        // get convolution descriptor
+        cudnnConvolutionDescriptor_t convDesc;
+        checkCudnnError(cudnnCreateConvolutionDescriptor(&convDesc));
+        // TODO: CUDNN_CONVOLUTION is a tunable argument
+        checkCudnnError(cudnnSetConvolution2dDescriptor(
+            convDesc, ph, pw, sh, sw, dh, dw, MODES[record->mode],
+            CUDNN_DATA_HALF)); /*fp16 type*/
+        if (g > 1) {
+            checkCudnnError(cudnnSetConvolutionGroupCount(convDesc, g));
+        }
+
+        // get activation descriptor
+        cudnnActivationDescriptor_t actDesc;
+        checkCudnnError(cudnnCreateActivationDescriptor(&actDesc));
+        // NOT_PROPAGATE_NAN is requierd by
+        // cudnnConvolotionBiasActivationForward
+        switch (op->getAct()) {
+        case ActType::Relu:
+            checkCudnnError(cudnnSetActivationDescriptor(
+                actDesc, CUDNN_ACTIVATION_RELU, CUDNN_NOT_PROPAGATE_NAN, 0));
+            break;
+        case ActType::Sigmoid:
+            checkCudnnError(cudnnSetActivationDescriptor(
+                actDesc, CUDNN_ACTIVATION_SIGMOID, CUDNN_NOT_PROPAGATE_NAN, 0));
+            break;
+        case ActType::None:
+            checkCudnnError(
+                cudnnSetActivationDescriptor(actDesc, CUDNN_ACTIVATION_IDENTITY,
+                                             CUDNN_NOT_PROPAGATE_NAN, 0));
+            break;
+        default:
+            assert(false);
+        }
+
+        // get output descriptor
+        int outn, outc, outh, outw;
+        checkCudnnError(cudnnGetConvolution2dForwardOutputDim(
+            convDesc, inDesc, knDesc, &outn, &outc, &outh, &outw));
+        cudnnTensorDescriptor_t outDesc;
+        checkCudnnError(cudnnCreateTensorDescriptor(&outDesc));
+        checkCudnnError(cudnnSetTensor4dDescriptor(outDesc, CUDNN_TENSOR_NCHW,
+                                                   CUDNN_DATA_HALF, outn, outc,
+                                                   outh, outw));
+        IT_ASSERT((vector{outn, outc, outh, outw}) ==
+                      op->getOutput()->getDims(),
+                  "cuDNN output shape mismatches with OP output shape");
+
+        return tuple(inData, knData, outData, inDesc, knDesc, biasDesc,
+                     convDesc, actDesc, outDesc);
+    }
+
+    bool cuDNNUnfused(const Ref<ConvObj> &op, const ConvCuDnnPerfRecord &record,
+                      const CudaRuntimeObj *context) const {
+        cudnnStatus_t stat;
+
+        const auto &[inData, knData, outData, inDesc, knDesc, biasDesc,
+                     convDesc, actDesc, outDesc] =
+            createCuDNNDescriptor(op, record);
+        size_t wsSize = record->workspaceSize;
+        CudaPtr wsData = context->getWorkspace(wsSize);
+        float alpha = 1.f, beta = 0.f;
+
+        stat = cudnnConvolutionForward(context->cudnnHandle(), &alpha, inDesc,
+                                       inData, knDesc, knData, convDesc,
+                                       ALGOS[record->algo], wsData, wsSize,
+                                       &beta, outDesc, outData);
+        if (stat != CUDNN_STATUS_SUCCESS)
+            return false;
+        // TODO:
+        // // bias
+        // if (bias != nullptr) {
+        //     auto sz = op.getOutputs()[0]->size();
+        //     // TODO: element wise
+        //     t += sz * 2 / 400;
+        // }
+        // // act
+        // if (act != None) {
+        //     stat = cudnnActivationForward(cudnnHandle(), actDesc,
+        //                                   &alpha, inDesc, inData,
+        //                                   &beta, outDesc, outData);
+        //     checkCudaError(cudaDeviceSynchronize());
+        //     end = ch::high_resolution_clock::now();
+        //     if (stat != CUDNN_STATUS_SUCCESS) {
+        //         durtime = INFINITY;
+        //         break;
+        //     }
+        //     t +=
+        //         ch::duration_cast<ch::duration<double>>(end -
+        //         beg).count() * 1000; // ms
+        // }
+
+        // best = ConvResult{durtime, ALGOS[i], wsSize, false};
+
+        // // w/ bias & act
+        // for (int j = 0; j < rounds + warmupRounds; ++j) {
+        //     cudnnStatus_t stat;
+        //     if (j == warmupRounds) {
+        //         checkCudaError(cudaDeviceSynchronize());
+        //         beg = ch::high_resolution_clock::now();
+        //     }
+        //     stat = cudnnConvolutionBiasActivationForward(
+        //         cudnnHandle(), &alpha, inDesc, inData, knDesc, knData,
+        //         convDesc, ALGOS[i], wsData, wsSize, &beta, outDesc,
+        //         outData, biasDesc, biasData, actDesc, outDesc, outData);
+        //     if (stat != CUDNN_STATUS_SUCCESS) {
+        //         // checkCudnnError(stat);
+        //         // Do not checkCudnnError since not all algorithms are
+        //         // supported
+        //         durtime_fuse = INFINITY;
+        //         break;
+        //     }
+        // }
+
+        // Destories in CUDA does not require sync. But cuDNN does not state
+        // whether sync is required before destories.
+        checkCudnnError(cudnnDestroyTensorDescriptor(outDesc));
+        checkCudnnError(cudnnDestroyActivationDescriptor(actDesc));
+        checkCudnnError(cudnnDestroyConvolutionDescriptor(convDesc));
+        checkCudnnError(cudnnDestroyTensorDescriptor(biasDesc));
+        checkCudnnError(cudnnDestroyFilterDescriptor(knDesc));
+        checkCudnnError(cudnnDestroyTensorDescriptor(inDesc));
+        return true;
+    }
+
+    void compute(const Operator &op, const RuntimeObj *context) const override {
+        auto record = make_ref<ConvCuDnnPerfRecordObj>(); // with paramters in
+                                                          // default ctor
+        compute(op, record, context);
+    }
+
+    PerfRecord tune(const Operator &_op,
+                    const RuntimeObj *_context) const override {
+        ConvCuDnnPerfRecordObj ret;
+        ret.time = std::numeric_limits<double>::max();
+        auto context = dynamic_cast<const CudaRuntimeObj *>(_context);
+        auto op = as<ConvObj>(_op);
+        // Both modes have the same performance. Only run cross-correlation.
+        for (int mode = 1; mode < 2; mode++) {
+            // Try every possible algorithm of convolution
+            for (int algo = 0; algo < N_ALGO; algo++) {
+                auto recordRef = make_ref<ConvCuDnnPerfRecordObj>();
+                auto &record = *recordRef;
+                record.mode = mode;
+                record.algo = algo;
+                cudnnStatus_t stat;
+                const auto &[inData, knData, outData, inDesc, knDesc, biasDesc,
+                             convDesc, actDesc, outDesc] =
+                    createCuDNNDescriptor(op, recordRef);
+
+                // get workspace
+                stat = cudnnGetConvolutionForwardWorkspaceSize(
+                    context->cudnnHandle(), inDesc, knDesc, convDesc, outDesc,
+                    ALGOS[record.algo], &record.workspaceSize);
+                if (stat != CUDNN_STATUS_SUCCESS)
+                    continue;
+                if (record.workspaceSize > context->getWorkspaceSize())
+                    continue;
+                CudaPtr wsData = context->getWorkspace(record.workspaceSize);
+                float alpha = 1.f, beta = 0.f;
+
+                stat = cudnnConvolutionForward(
+                    context->cudnnHandle(), &alpha, inDesc, inData, knDesc,
+                    knData, convDesc, ALGOS[record.algo], wsData,
+                    record.workspaceSize, &beta, outDesc, outData);
+                if (stat != CUDNN_STATUS_SUCCESS)
+                    continue;
+                record.time = timeit(
+                    [&]() {
+                        cudnnConvolutionForward(context->cudnnHandle(), &alpha,
+                                                inDesc, inData, knDesc, knData,
+                                                convDesc, ALGOS[record.algo],
+                                                wsData, record.workspaceSize,
+                                                &beta, outDesc, outData);
+                    },
+                    [&]() { context->sync(); });
+                // printf("mode:%d algo:%d :%.8lf\n", mode, algo, record.time);
+
+                // Update the tune result
+                if (ret.time > record.time)
+                    ret = record;
+                checkCudnnError(cudnnDestroyTensorDescriptor(outDesc));
+                checkCudnnError(cudnnDestroyActivationDescriptor(actDesc));
+                checkCudnnError(cudnnDestroyConvolutionDescriptor(convDesc));
+                checkCudnnError(cudnnDestroyTensorDescriptor(biasDesc));
+                checkCudnnError(cudnnDestroyFilterDescriptor(knDesc));
+                checkCudnnError(cudnnDestroyTensorDescriptor(inDesc));
+            }
+        }
+        // printf("the best algo is %d, the best conv mode is %d\n", ret.algo,
+        //        ret.mode);
+        IT_ASSERT(ret.time < std::numeric_limits<double>::max(), "No valid "
+                                                                 "algorithm "
+                                                                 "found");
+        return make_ref<ConvCuDnnPerfRecordObj>(ret);
+    }
+
+    void compute(const Operator &_op, const PerfRecord &_record,
+                 const RuntimeObj *_context) const override {
+        auto op = as<ConvObj>(_op);
+        auto record = as<ConvCuDnnPerfRecordObj>(_record);
+        auto context = dynamic_cast<const CudaRuntimeObj *>(_context);
+        bool success = cuDNNUnfused(op, record, context);
+        IT_ASSERT(success);
+    }
+};
+
+REGISTER_KERNEL(Device::CUDA, OpType::Conv, DataType::Float16, convCudnnHalf,
+                "Conv_cuDNN_CUDA_Float16");
+
+REGISTER_CONSTRUCTOR(1, ConvCuDnnPerfRecordObj::from_json);
+} // namespace infini

--- a/src/utils/data_convert.cc
+++ b/src/utils/data_convert.cc
@@ -1,0 +1,30 @@
+#include "utils/data_convert.h"
+
+namespace infini {
+
+uint16_t float_to_fp16(const float x) {
+    Uf32 u;
+    u.f32 = x;
+    const uint32_t b = u.u32 + 0x00001000;
+    const uint32_t e = (b & 0x7F800000) >> 23;
+    const uint32_t m = b & 0x007FFFFF;
+    return (b & 0x80000000) >> 16 |
+           (e > 112) * ((((e - 112) << 10) & 0x7C00) | m >> 13) |
+           ((e < 113) & (e > 101)) *
+               ((((0x007FF000 + m) >> (125 - e)) + 1) >> 1) |
+           (e > 143) * 0x7FFF;
+}
+
+float fp16_to_float(const uint16_t x) {
+    Uf32 u;
+    const uint32_t e = (x & 0x7C00) >> 10;
+    const uint32_t m = (x & 0x03FF) << 13;
+    u.f32 = (float)m;
+    const uint32_t v = u.u32 >> 23;
+    const uint32_t r = (x & 0x8000) << 16 | (e != 0) * ((e + 112) << 23 | m) |
+                       ((e == 0) & (m != 0)) *
+                           ((v - 37) << 23 | ((m << (150 - v)) & 0x007FE000));
+    u.u32 = r;
+    return u.f32;
+}
+} // namespace infini

--- a/test/core/test_graph_handler.cc
+++ b/test/core/test_graph_handler.cc
@@ -7,9 +7,9 @@ namespace infini {
 TEST(Handler, matmul) {
     auto runtime = NativeCpuRuntimeObj::getInstance();
     auto handler = make_ref<GraphHandlerObj>(runtime);
-    auto i = handler->tensor({1, 2, 3}, OnnxDType::UINT32);
-    auto w = handler->tensor({1, 3, 4}, OnnxDType::UINT32);
-    auto o = handler->tensor({1, 2, 4}, OnnxDType::UINT32);
+    auto i = handler->tensor({1, 2, 3}, DataType::UInt32.getIndex());
+    auto w = handler->tensor({1, 3, 4}, DataType::UInt32.getIndex());
+    auto o = handler->tensor({1, 2, 4}, DataType::UInt32.getIndex());
     handler->matmul(i, w, o, false, false, nullptr, ActType::None);
 }
 

--- a/test/kernels/cuda/test_cuda_conv_fp16.cc
+++ b/test/kernels/cuda/test_cuda_conv_fp16.cc
@@ -1,0 +1,78 @@
+#include "core/graph.h"
+#include "core/kernel.h"
+#include "core/runtime.h"
+#include "cuda/cuda_runtime.h"
+#include "cuda/cuda_utility.h"
+#include "operators/conv.h"
+#include <bitset>
+
+#include "test.h"
+
+namespace infini {
+
+void testConvCudnnFP16(
+    const std::function<void(void *, size_t, DataType)> &generator,
+    vector<float> ansVec) {
+
+    // Construct Runtime and graph for CPU and CUDA
+    Runtime cpu = NativeCpuRuntimeObj::getInstance(); // CPUruntime is singleton
+    Graph gCpu = make_ref<GraphObj>(cpu);
+    Runtime cuda = make_ref<CudaRuntimeObj>();
+    Graph gCuda = make_ref<GraphObj>(cuda);
+    // Set input data on CPU in a CPU Graph
+    Tensor i0Cpu = gCpu->addTensor({1, 3, 4, 4}, DataType::Float16);
+    Tensor w0Cpu = gCpu->addTensor({2, 3, 3, 3}, DataType::Float16);
+    // Malloc data for all tensors in a graph. Do we need implicit allocation?
+    gCpu->dataMalloc();
+    i0Cpu->setData(generator);
+    w0Cpu->setData(generator);
+
+    // Copy input tensors from CPU to CUDA
+    Tensor i0Cuda = gCuda->cloneTensor(i0Cpu);
+    Tensor w0Cuda = gCuda->cloneTensor(w0Cpu);
+    // Build CUDA graph
+    auto conv =
+        gCuda->addOp<ConvObj>(i0Cuda, w0Cuda, nullptr, 1, 1, 2, 1, 1, 2);
+    // allocate CUDA memory
+    gCuda->dataMalloc();
+    // Execute on CUDA
+    cuda->run(gCuda);
+    // copy output from CUDA to CPU
+    auto o0Cpu = gCpu->cloneTensor(conv->getOutput());
+    // check results on CPU
+    EXPECT_TRUE(o0Cpu->equalData(ansVec));
+    // print a tensor/operator/graph by print()
+    gCuda->print();
+}
+
+TEST(cuDNN_Conv_FP16, run) {
+    testConvCudnnFP16(IncrementalGenerator(),
+                      vector<float>{48, 48, 72, 72, 48, 48, 72, 72});
+}
+
+TEST(cuDNN_Conv_FP16, tune) {
+    Runtime cpu = NativeCpuRuntimeObj::getInstance(); // CPUruntime is singleton
+    Graph gCpu = make_ref<GraphObj>(cpu);
+    Runtime cuda = make_ref<CudaRuntimeObj>();
+    Graph gCuda = make_ref<GraphObj>(cuda);
+    // Set input data on CPU in a CPU Graph
+    Tensor i0Cpu = gCpu->addTensor({1, 3, 224, 224}, DataType::Float16);
+    Tensor w0Cpu = gCpu->addTensor({2, 3, 3, 3}, DataType::Float16);
+    // Malloc data for all tensors in a graph. Do we need implicit allocation?
+    gCpu->dataMalloc();
+    i0Cpu->setData(IncrementalGenerator());
+    w0Cpu->setData(IncrementalGenerator());
+
+    // Copy input tensors from CPU to CUDA
+    Tensor i0Cuda = gCuda->cloneTensor(i0Cpu);
+    Tensor w0Cuda = gCuda->cloneTensor(w0Cpu);
+    // Build CUDA graph
+    auto conv =
+        gCuda->addOp<ConvObj>(i0Cuda, w0Cuda, nullptr, 1, 1, 1, 1, 1, 1);
+    // allocate CUDA memory
+    gCuda->dataMalloc();
+    // Execute on CUDA
+    bool tune = true;
+    cuda->run(gCuda, tune);
+}
+} // namespace infini


### PR DESCRIPTION
新增内容：
1.在框架内新增DataType::Float16对应ONNX中TensorProto::FLOAT16，并以uint8形式实现相应的数据copy
2.修改原有copyin中的防呆方法
3.为了测试resnet网络新增了flatten算子的onnx导出
4.由于调试中将chenjie和zhangyue的代码进行了微调，所以将其commit一并合入此commit中进行提交合入
测试：
1.本地以resnet模型为例，使用onnx自带的convert_fp16的功能将inputs转为fp16，测试模型的读入、构图、导出，均可以通过
2.搭建conv的单算子网络，设定输入为fp16类型，进行集成测试，可以顺利走到运行时成功调起kernel
3.在test_onnx.py文件中增加了conv fp16和flatten op的构图测试