### PR TITLE
build: 实现格式化 git added c/c++ 源码的脚本

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-﻿.PHONY : build clean install-python test-cpp test-onnx
+﻿.PHONY : build clean format install-python test-cpp test-onnx
 
 TYPE ?= release
 CUDA ?= OFF
@@ -23,6 +23,9 @@ build:
 
 clean:
 	rm -rf build
+
+format:
+	python3 scripts/format.py
 
 install-python: build
 	cp build/$(TYPE)/backend*.so pyinfinitensor/src/pyinfinitensor

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ BANG ?= OFF
 INTELCPU ?= off
 BACKTRACE ?= ON
 TEST ?= ON
+FORMAT_ORIGIN ?=
 
 CMAKE_OPT = -DCMAKE_BUILD_TYPE=$(TYPE)
 CMAKE_OPT += -DUSE_CUDA=$(CUDA)
@@ -25,7 +26,7 @@ clean:
 	rm -rf build
 
 format:
-	python3 scripts/format.py
+	@python3 scripts/format.py $(FORMAT_ORIGIN)
 
 install-python: build
 	cp build/$(TYPE)/backend*.so pyinfinitensor/src/pyinfinitensor

--- a/scripts/format.py
+++ b/scripts/format.py
@@ -2,6 +2,7 @@
 import sys
 from pathlib import Path
 
+c_style_file = [".h", ".hh", ".hpp", ".c", ".cc", ".cpp", ".cxx", ".cu", ".mlu"]
 proj_path = Path(sys.path[0]).parent
 
 for line in (
@@ -14,7 +15,7 @@ for line in (
     for pre in ["new file:", "modified:"]:
         if line.startswith(pre):
             file = Path(proj_path.joinpath(line[len(pre) :].strip()))
-            if file.suffix in [".h", ".hh", ".hpp", ".c", ".cc", ".cpp", ".cxx"]:
+            if file.suffix in c_style_file:
                 run(f"clang-format-14 -i {file}", cwd=proj_path, shell=True)
                 run(f"git add {file}", cwd=proj_path, shell=True)
         break

--- a/scripts/format.py
+++ b/scripts/format.py
@@ -1,0 +1,20 @@
+﻿from subprocess import run
+import sys
+from pathlib import Path
+
+proj_path = Path(sys.path[0]).parent
+
+for line in (
+    run("git status", cwd=proj_path, capture_output=True, shell=True)
+    .stdout.decode()
+    .splitlines()
+):
+    line = line.strip()
+    # Only formats git added files.
+    for pre in ["new file:", "modified:"]:
+        if line.startswith(pre):
+            file = Path(proj_path.joinpath(line[len(pre) :].strip()))
+            if file.suffix in [".h", ".hh", ".hpp", ".c", ".cc", ".cpp", ".cxx"]:
+                run(f"clang-format-14 -i {file}", cwd=proj_path, shell=True)
+                run(f"git add {file}", cwd=proj_path, shell=True)
+        break

--- a/scripts/format.py
+++ b/scripts/format.py
@@ -3,6 +3,7 @@ import sys
 from pathlib import Path
 
 c_style_file = [".h", ".hh", ".hpp", ".c", ".cc", ".cpp", ".cxx", ".cu", ".mlu"]
+py_file = ".py"
 proj_path = Path(sys.path[0]).parent
 
 for line in (
@@ -17,5 +18,8 @@ for line in (
             file = Path(proj_path.joinpath(line[len(pre) :].strip()))
             if file.suffix in c_style_file:
                 run(f"clang-format-14 -i {file}", cwd=proj_path, shell=True)
+                run(f"git add {file}", cwd=proj_path, shell=True)
+            elif file.suffix == py_file:
+                run(f"black {file}", cwd=proj_path, shell=True)
                 run(f"git add {file}", cwd=proj_path, shell=True)
         break

--- a/scripts/format.py
+++ b/scripts/format.py
@@ -1,25 +1,50 @@
-﻿from subprocess import run
-import sys
+﻿import sys
 from pathlib import Path
+from subprocess import run
 
 c_style_file = [".h", ".hh", ".hpp", ".c", ".cc", ".cpp", ".cxx", ".cu", ".mlu"]
 py_file = ".py"
 proj_path = Path(sys.path[0]).parent
 
-for line in (
-    run("git status", cwd=proj_path, capture_output=True, shell=True)
-    .stdout.decode()
-    .splitlines()
-):
-    line = line.strip()
-    # Only formats git added files.
-    for pre in ["new file:", "modified:"]:
-        if line.startswith(pre):
-            file = Path(proj_path.joinpath(line[len(pre) :].strip()))
-            if file.suffix in c_style_file:
-                run(f"clang-format-14 -i {file}", cwd=proj_path, shell=True)
-                run(f"git add {file}", cwd=proj_path, shell=True)
-            elif file.suffix == py_file:
-                run(f"black {file}", cwd=proj_path, shell=True)
-                run(f"git add {file}", cwd=proj_path, shell=True)
-        break
+
+# Formats one file under project path.
+def format_file(file):
+    file = Path(proj_path.joinpath(file))
+    if file.suffix in c_style_file:
+        run(f"clang-format-14 -i {file}", cwd=proj_path, shell=True)
+        run(f"git add {file}", cwd=proj_path, shell=True)
+    elif file.suffix == py_file:
+        run(f"black {file}", cwd=proj_path, shell=True)
+        run(f"git add {file}", cwd=proj_path, shell=True)
+
+
+if len(sys.argv) == 1:
+    # Last commit.
+    print("Formats git added files.")
+    for line in (
+        run("git status", cwd=proj_path, capture_output=True, shell=True)
+        .stdout.decode()
+        .splitlines()
+    ):
+        line = line.strip()
+        # Only formats git added files.
+        for pre in ["new file:", "modified:"]:
+            if line.startswith(pre):
+                format_file(line[len(pre) :].strip())
+            break
+else:
+    # Origin commit.
+    origin = sys.argv[1]
+    print(f'Formats changed files from "{origin}".')
+    for line in (
+        run(f"git diff {origin}", cwd=proj_path, capture_output=True, shell=True)
+        .stdout.decode()
+        .splitlines()
+    ):
+        diff = "diff --git "
+        if line.startswith(diff):
+            files = line[len(diff) :].split(" ")
+            assert len(files) == 2
+            assert files[0][:2] == "a/"
+            assert files[1][:2] == "b/"
+            format_file(files[1][2:])

--- a/test/script/clang_format_inplace.sh
+++ b/test/script/clang_format_inplace.sh
@@ -1,4 +1,0 @@
-#!/usr/bin/env bash
-script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]:-$0}")" &>/dev/null && pwd 2>/dev/null)"
-PET_HOME="$(readlink -f ${script_dir}/../..)"
-find ${PET_HOME}/src ${PET_HOME}/include ${PET_HOME}/test  -iname *.h -o -iname *.cc | xargs clang-format -i


### PR DESCRIPTION
| Notice | Ready for review
|--------|-
| Based on | `master`

添加一个 Python 脚本，支持使用 `clang-format-14` 格式化  c/c++ 文件，使用 `black` 格式化 python 文件。

---

可以通过 Makefile 调用：

```bash
make format
```

以格式化当前所有 *git added* 文件。

调用：

```bash
make format FORMAT_ORIGIN=<commit>
```

以格式化从 `commit` 指定的提交开始所有修改过的文件，`commit` 可以是 id，也可以是 tag 或分支的名字。