### PR TITLE
Fix support kvcache

### DIFF
--- a/examples/distributed/parallel_opt.py
+++ b/examples/distributed/parallel_opt.py
@@ -60,7 +60,7 @@ def parallel_model(model: ModelProto, tp_world_size: int = 1, tp_rank: int = 0):
     def shard_concat(node: NodeProto):
         # hack for kvcache
         in_plc = place[node.input[1]]
-        if in_plc.is_sharded():
+        if in_plc.is_shard():
             seq_len_dim = vinfo[node.input[0]].type.tensor_type.shape.dim.pop(1)
             seq_len_dim.dim_value //= tp_world_size
             vinfo[node.input[0]].type.tensor_type.shape.dim.insert(1, seq_len_dim)

--- a/pyinfinitensor/src/pyinfinitensor/onnx.py
+++ b/pyinfinitensor/src/pyinfinitensor/onnx.py
@@ -46,6 +46,7 @@ class OnnxStub:
             dims = [d for d in initializer.dims]
             tensors[initializer.name] = self.handler.tensor(dims, initializer.data_type)
             data[initializer.name] = initializer
+            tensors[initializer.name].set_weight()
 
         for input in model.graph.input:
             dims = _take_shape_dim(input.type.tensor_type.shape)
@@ -53,12 +54,14 @@ class OnnxStub:
                 tensors[input.name] = self.handler.tensor(
                     dims, input.type.tensor_type.elem_type
                 )
+                tensors[input.name].set_input()
 
         for output in model.graph.output:
             dims = _take_shape_dim(output.type.tensor_type.shape)
             tensors[output.name] = self.handler.tensor(
                 dims, output.type.tensor_type.elem_type
             )
+            tensors[output.name].set_output()
 
 
         node_name = []
@@ -665,19 +668,6 @@ class OnnxStub:
                 new_node_name.append(node.name)
             # update the node_list
             node_list = list(set(node_name) - set(new_node_name))
-
-        ################################
-        # Set tensor type
-        ################################
-        for initializer in model.graph.initializer:
-            tensors[initializer.name].set_weight()
-
-        for input in model.graph.input:
-            tensors[input.name].set_input()
-        
-        for output in model.graph.output:
-            tensors[output.name].set_output()
-
 
         ################################
         # Allocate memory space for data


### PR DESCRIPTION
添加之前没有 cherry-pick 过来的 commit，包括两部分：

1. 修复 parallel_opt.py 里使用的判断是否切分的函数名；
2. 修改标记 tensor 类型的位置（因为发现某些 onnx 文件中，input.name 里也包含了所有的 initializer.name，为避免标记被覆盖，所以将打标记的时间提前到创建 tensor 的时候，并且对 name 进行了特判防止重复创建 tensor）。