### PR TITLE
Change onnx-simplifier to onnxsim to resolve build issue on xpu

### DIFF
--- a/pyinfinitensor/pyproject.toml
+++ b/pyinfinitensor/pyproject.toml
@@ -12,7 +12,7 @@ requires-python = ">=3.7"
 keywords = ["optimizer"]
 license = { text = "Apache" }
 classifiers = ["Programming Language :: Python :: 3"]
-dependencies = ["onnx","onnx-simplifier"]
+dependencies = ["onnx","onnxsim"]
 
 [tool.setuptools.packages.find]
 where = ["src"]


### PR DESCRIPTION
Build succeeds in xpu
```
Building wheels for collected packages: pyinfinitensor
  Building editable for pyinfinitensor (pyproject.toml) ... done
  Created wheel for pyinfinitensor: filename=pyinfinitensor-0.0.0-0.editable-py3-none-any.whl size=1432 sha256=96d42080fcef4093329743e684722bb5f75909df8734c343c3f6277bfc6b1a3b
  Stored in directory: /tmp/pip-ephem-wheel-cache-mr7k1jrl/wheels/46/2d/7a/2f80651edab17efcac589ffe8a23644eb83b8fc4e97e29e927
Successfully built pyinfinitensor
Installing collected packages: pyinfinitensor
  Attempting uninstall: pyinfinitensor
    Found existing installation: pyinfinitensor 0.0.0
    Uninstalling pyinfinitensor-0.0.0:
      Successfully uninstalled pyinfinitensor-0.0.0
Successfully installed pyinfinitensor-0.0.0
```