### PR TITLE
Fix compilation failure with TEST=OFF

### DIFF
--- a/include/core/common.h
+++ b/include/core/common.h
@@ -12,6 +12,7 @@
 #include <tuple>
 #include <unordered_map>
 #include <unordered_set>
+#include <variant>
 #include <vector>
 
 namespace infini {

--- a/src/core/graph_handler.cc
+++ b/src/core/graph_handler.cc
@@ -30,7 +30,6 @@
 #include "operators/unsqueeze.h"
 #include "operators/where.h"
 #include <numeric>
-#include <variant>
 
 namespace infini {
 


### PR DESCRIPTION
Due to the googletest with variant included, the cmake will auto link gtest's variant library, ranther than in the graph_handler.cc
Thus the the compilation will fail with TEST=OFF, while succeed with TEST=ON
To solve this, the #include <variant> should be moved from graph_handler.cc to core/common.h
There is no need to adjust the include in nnet, because it is conditional macro statement.