### PR TITLE
Fix RoPE output data type inference

### DIFF
--- a/include/operators/rope.h
+++ b/include/operators/rope.h
@@ -15,6 +15,7 @@ class RoPEObj : public OperatorObj {
     RoPEObj(GraphObj *graph, Tensor pos, Tensor input, Tensor output);
     OP_CLONE(RoPEObj);
     optional<vector<Shape>> inferShape(const TensorVec &inputs) override;
+    vector<DataType> inferDataType(const TensorVec &inputs) const override;
 
     std::string toString() const override;
     int numInputs() const override { return 2; }

--- a/src/operators/rope.cc
+++ b/src/operators/rope.cc
@@ -13,6 +13,10 @@ optional<vector<Shape>> RoPEObj::inferShape(const TensorVec &inputs) {
     return {{output_dim}};
 }
 
+vector<DataType> RoPEObj::inferDataType(const TensorVec &inputs) const {
+    return {inputs[1]->getDType()};
+}
+
 std::string RoPEObj::toString() const {
     std::ostringstream os;
     os << type.toString() << "[" << getGuid() << "]";

--- a/test/operators/test_rope.cc
+++ b/test/operators/test_rope.cc
@@ -1,0 +1,46 @@
+#include "core/graph.h"
+#include "core/runtime.h"
+#include "operators/rope.h"
+
+#include "test.h"
+
+namespace infini {
+
+TEST(RoPE, InferOutputDataType) {
+    auto runtime = NativeCpuRuntimeObj::getInstance();
+
+    {
+        Graph graph = make_ref<GraphObj>(runtime);
+        auto positions = graph->addTensor({1, 2}, DataType::Int32);
+        auto input = graph->addTensor({1, 2, 128}, DataType::Float32);
+        auto rope = graph->addOp<RoPEObj>(positions, input, nullptr);
+
+        EXPECT_EQ(rope->getOutput()->getDims(), (Shape{1, 2, 128}));
+        EXPECT_EQ(rope->getOutput()->getDType(), DataType::Float32);
+    }
+
+    {
+        Graph graph = make_ref<GraphObj>(runtime);
+        auto positions = graph->addTensor({1, 2}, DataType::Int64);
+        auto input = graph->addTensor({1, 2, 128}, DataType::Float16);
+        auto rope = graph->addOp<RoPEObj>(positions, input, nullptr);
+
+        EXPECT_EQ(rope->getOutput()->getDims(), (Shape{1, 2, 128}));
+        EXPECT_EQ(rope->getOutput()->getDType(), DataType::Float16);
+    }
+}
+
+TEST(RoPE, PreserveExplicitOutput) {
+    auto runtime = NativeCpuRuntimeObj::getInstance();
+    Graph graph = make_ref<GraphObj>(runtime);
+    auto positions = graph->addTensor({1, 2}, DataType::Int32);
+    auto input = graph->addTensor({1, 2, 128}, DataType::Float32);
+    auto output = graph->addTensor({1, 2, 128}, DataType::Float32);
+    auto rope = graph->addOpWithOutputs<RoPEObj>(positions, input, output);
+
+    EXPECT_EQ(rope->getOutput(), output);
+    EXPECT_EQ(rope->getOutput()->getDims(), (Shape{1, 2, 128}));
+    EXPECT_EQ(rope->getOutput()->getDType(), DataType::Float32);
+}
+
+} // namespace infini


### PR DESCRIPTION
## 问题

RoPE 在隐式创建输出 Tensor 时，默认继承第一个输入 `position_ids` 的数据类型。

当输入为：

- `position_ids`: `INT32` 或 `INT64`
- `input`: `FLOAT16` 或 `FLOAT32`

输出会被错误推导为整数类型，导致后续 RoPE 计算无法正常执行。

## 修改

- 为 `RoPEObj` 实现 `inferDataType()`。
- RoPE 输出类型明确跟随第二个输入 `input`。
- 保持现有输入顺序、Shape 推导和显式输出行为不变。
- 新增测试覆盖：
  - `INT32 position_ids + FLOAT32 input`
  - `INT64 position_ids + FLOAT16 input`
  - 显式输出 Tensor 的 Shape、类型和对象保持不变

## 测试

- CPU Release 全量 CTest：`41/41` 通过
- CUDA 12.8，`sm_89` Release 全量 CTest：`78/78` 通过
- 原有 CUDA RoPE 数值测试通过
- `git diff --check` 通过