### PR TITLE
Fix memory management for dynamic shapes

### DIFF
--- a/include/core/blob.h
+++ b/include/core/blob.h
@@ -11,14 +11,21 @@ class BlobObj {
     // Runtime might be replaced with a raw pointer for optimization
     Runtime runtime;
     void *ptr;
+    size_t bytes;
+    Ref<BlobObj> owner;
 
   public:
-    BlobObj(Runtime runtime, void *ptr) : runtime(runtime), ptr(ptr) {}
+    BlobObj(Runtime runtime, void *ptr, size_t bytes);
+    BlobObj(Ref<BlobObj> owner, size_t offset, size_t bytes);
     BlobObj(BlobObj &other) = delete;
     BlobObj &operator=(BlobObj const &) = delete;
-    ~BlobObj();
+    ~BlobObj() noexcept;
 
-    template <typename T> T getPtr() const { return reinterpret_cast<T>(ptr); }
+    size_t getBytes() const { return bytes; }
+    template <typename T> T getPtr() const {
+        IT_ASSERT(ptr != nullptr, "Blob has no backing memory");
+        return reinterpret_cast<T>(ptr);
+    }
 };
 
 } // namespace infini

--- a/include/core/graph.h
+++ b/include/core/graph.h
@@ -71,6 +71,10 @@ class GraphObj : public Object {
 
     void dataMalloc(bool useNaiveAllocator = false, size_t memPoolSize = 0);
 
+    void validateMemory() const;
+
+    size_t getAllocationGeneration() const { return allocationGeneration; }
+
     Tensor cloneKV(Tensor &tensor);
 
     void freeHeap();
@@ -134,6 +138,20 @@ class GraphObj : public Object {
      * @brief If the weight tensors are allocated.
      */
     bool weightAllocated = false;
+
+    /**
+     * @brief Incremented after each successful memory layout update.
+     */
+    size_t allocationGeneration = 0;
+
+    /**
+     * Fixed memory pools cannot safely move live data within the same backing
+     * allocation. Remember the committed layout so changes can be rejected
+     * before any tensor data is modified.
+     */
+    bool fixedPoolLayoutCommitted = false;
+    vector<std::pair<TensorObj *, size_t>> fixedPoolTensorLayout;
+    vector<std::pair<TensorObj *, size_t>> fixedPoolActivationLayout;
 };
 
 } // namespace infini

--- a/include/core/lazy_allocator.h
+++ b/include/core/lazy_allocator.h
@@ -35,13 +35,13 @@ class LazyAllocator {
     size_t memPoolSize = 0;
 
     // pointer to the memory actually allocated
-    void *ptr = nullptr;
+    Blob ptr;
 
     // pointer to the weight memory space
-    void *weightPtr = nullptr;
+    Blob weightPtr;
 
     // memory pool ptr
-    void *memPoolPtr = nullptr;
+    Blob memPoolPtr;
 
     // // a cache designed for a batch size that has already occurred
     // std::unordered_map<size_t, std::unordered_map<TensorObj *, size_t>>
@@ -77,6 +77,8 @@ class LazyAllocator {
 
     void init();
 
+    void resetWeightPlan();
+
     void setMemPool(size_t memPoolSize);
 
     bool getMemPoolStatus();
@@ -107,9 +109,15 @@ class LazyAllocator {
 
     // std::unordered_map<TensorObj *, size_t> getCache(size_t batchsize);
 
+    Blob getActivationBlob(size_t offset, size_t bytes);
+
     void *getWeightPtr();
 
+    Blob getWeightBlob(size_t offset, size_t bytes);
+
     void *getHeapPtr();
+
+    Blob getHeapBlob(size_t offset, size_t bytes);
 
     void info();
 

--- a/include/cuda/cuda_runtime.h
+++ b/include/cuda/cuda_runtime.h
@@ -17,6 +17,11 @@ class CudaRuntimeObj : public RuntimeObj {
     bool isCudaGraphCreated;
     cudaGraph_t cudaGraph;
     cudaGraphExec_t cudaGraphInstance;
+    WRef<GraphObj> cudaGraphOwner;
+    size_t cudaGraphAllocationGeneration = 0;
+    vector<const TensorObj *> cudaGraphTensors;
+    vector<const void *> cudaGraphTensorAddresses;
+    vector<vector<int>> cudaGraphTensorShapes;
 
   public:
     explicit CudaRuntimeObj(int deviceId = 0)

--- a/pyinfinitensor/tests/test_onnxstub.py
+++ b/pyinfinitensor/tests/test_onnxstub.py
@@ -32,12 +32,12 @@ def initializer(name, values, dtype=None):
     return numpy_helper.from_array(array, name=name)
 
 
-def import_model(model, runtime=None):
+def import_model(model, runtime=None, use_naive_allocator=False):
     runtime = backend.cpu_runtime() if runtime is None else runtime
     with patch.object(
         onnx_frontend, "simplify", side_effect=lambda candidate: (candidate, False)
     ):
-        return OnnxStub(model, runtime)
+        return OnnxStub(model, runtime, use_naive_allocator=use_naive_allocator)
 
 
 def node_attribute(node, name):
@@ -148,15 +148,18 @@ class TestOnnxStubImport(unittest.TestCase):
             [value_info("y", [1, 2])],
             [initializer("weight", weight)],
         )
-        stub = import_model(model)
-
-        for batch in (2, 3):
-            x = np.arange(batch * 2, dtype=np.float32).reshape(batch, 2)
-            stub.set_input([[batch, 2]])
-            stub.inputs["x"].copyin_numpy(x)
-            stub.run()
-            actual = np.asarray(stub.outputs["y"].copyout_float()).reshape(batch, 2)
-            np.testing.assert_allclose(actual, x @ weight)
+        for use_naive_allocator in (False, True):
+            with self.subTest(use_naive_allocator=use_naive_allocator):
+                stub = import_model(model, use_naive_allocator=use_naive_allocator)
+                for batch in (2, 1, 8192, 3):
+                    x = np.arange(batch * 2, dtype=np.float32).reshape(batch, 2)
+                    stub.set_input([[batch, 2]])
+                    stub.inputs["x"].copyin_numpy(x)
+                    stub.run()
+                    actual = np.asarray(stub.outputs["y"].copyout_float()).reshape(
+                        batch, 2
+                    )
+                    np.testing.assert_allclose(actual, x @ weight)
 
 
 class TestStaticOnnxInputs(unittest.TestCase):
@@ -458,15 +461,22 @@ class TestOnnxStubCuda(unittest.TestCase):
             [value_info("y", [1, 2])],
             [initializer("weight", weight)],
         )
-        stub = import_model(model, backend.cuda_runtime())
-        x = np.arange(6, dtype=np.float32).reshape(3, 2)
-
-        stub.set_input([[3, 2]])
-        stub.inputs["x"].copyin_numpy(x)
-        stub.run()
-        actual = np.asarray(stub.outputs["y"].copyout_float()).reshape(3, 2)
-
-        np.testing.assert_allclose(actual, x @ weight, rtol=1e-5, atol=1e-6)
+        for use_naive_allocator in (False, True):
+            with self.subTest(use_naive_allocator=use_naive_allocator):
+                stub = import_model(
+                    model,
+                    backend.cuda_runtime(),
+                    use_naive_allocator=use_naive_allocator,
+                )
+                for batch in (3, 1, 8192, 2):
+                    x = np.arange(batch * 2, dtype=np.float32).reshape(batch, 2)
+                    stub.set_input([[batch, 2]])
+                    stub.inputs["x"].copyin_numpy(x)
+                    stub.run()
+                    actual = np.asarray(stub.outputs["y"].copyout_float()).reshape(
+                        batch, 2
+                    )
+                    np.testing.assert_allclose(actual, x @ weight, rtol=1e-5, atol=1e-6)
 
 
 if __name__ == "__main__":

--- a/src/ascend/ascend_runtime.cc
+++ b/src/ascend/ascend_runtime.cc
@@ -1,4 +1,5 @@
 #include "ascend/ascend_runtime.h"
+#include "core/graph.h"
 #include "core/kernel.h"
 #include "core/perf_engine.h"
 #ifdef INFINI_USE_HCCL
@@ -9,6 +10,8 @@ namespace infini {
 
 void ASCENDRuntimeObj::runWithoutSync(const Graph &graph, bool tune = false,
                                       bool profiling = false) const {
+    IT_ASSERT(graph != nullptr, "Cannot run a null graph");
+    graph->validateMemory();
     const auto &kernelRegistry = KernelRegistry::getInstance();
     auto &perfEngine = PerfEngine::getInstance();
     double totalTime = 0;

--- a/src/bang/bang_runtime.cc
+++ b/src/bang/bang_runtime.cc
@@ -1,4 +1,5 @@
 #include "bang/bang_runtime.h"
+#include "core/graph.h"
 #include "core/kernel.h"
 #include "core/perf_engine.h"
 #ifdef INFINI_USE_CNCL
@@ -9,6 +10,8 @@ namespace infini {
 
 void BangRuntimeObj::runWithoutSync(const Graph &graph, bool tune = false,
                                     bool profiling = false) const {
+    IT_ASSERT(graph != nullptr, "Cannot run a null graph");
+    graph->validateMemory();
     const auto &kernelRegistry = KernelRegistry::getInstance();
     auto &perfEngine = PerfEngine::getInstance();
     double totalTime = 0;

--- a/src/core/blob.cc
+++ b/src/core/blob.cc
@@ -1,11 +1,35 @@
 #include "core/blob.h"
 #include "core/runtime.h"
+#include <cstdio>
 
 namespace infini {
 
-BlobObj::~BlobObj() {
-    // Avoid cycled inclusion
-    // destruction is performed in LazyAllocator
+BlobObj::BlobObj(Runtime runtime, void *ptr, size_t bytes)
+    : runtime(std::move(runtime)), ptr(ptr), bytes(bytes) {
+    IT_ASSERT(this->runtime != nullptr, "Blob requires a runtime");
+    IT_ASSERT(ptr != nullptr, "Blob requires non-null backing memory");
+}
+
+BlobObj::BlobObj(Ref<BlobObj> owner, size_t offset, size_t bytes)
+    : runtime(owner ? owner->runtime : nullptr), ptr(nullptr), bytes(bytes),
+      owner(std::move(owner)) {
+    IT_ASSERT(this->owner != nullptr, "Blob view requires an owner");
+    IT_ASSERT(offset <= this->owner->bytes, "Blob view offset is out of range");
+    IT_ASSERT(bytes <= this->owner->bytes - offset,
+              "Blob view exceeds its owner");
+    ptr = static_cast<uint8_t *>(this->owner->ptr) + offset;
+}
+
+BlobObj::~BlobObj() noexcept {
+    if (!owner && ptr != nullptr) {
+        try {
+            runtime->dealloc(ptr);
+        } catch (const std::exception &error) {
+            std::fprintf(stderr, "Error in ~BlobObj: %s\n", error.what());
+        } catch (...) {
+            std::fputs("Unknown error in ~BlobObj\n", stderr);
+        }
+    }
 }
 
 } // namespace infini

--- a/src/core/graph.cc
+++ b/src/core/graph.cc
@@ -162,21 +162,23 @@ void GraphObj::dataMalloc(bool useNaiveAllocator, size_t memPoolSize) {
     if (useNaiveAllocator) {
         // can not set memory pool when use naive allocator
         IT_ASSERT(memPoolSize == 0);
-        // used for debugging memory out-of-bounds access, tensors will not be
-        // released correctly
-        // note: behavior may not match running in non-naive mode, and it may
-        // not reproduce the bug
+        // Used for debugging memory out-of-bounds access. Tensor memory is not
+        // reused, so behavior may not match non-naive mode or reproduce the
+        // same bug.
         for (auto &tensor : tensors) {
             if (!tensor->isWeight() ||
                 (tensor->isWeight() && !weightAllocated)) {
                 tensor->dataMalloc();
             }
         }
+        weightAllocated = true;
+        ++allocationGeneration;
         return;
     }
     if (memPoolSize > 0) {
         allocator.setMemPool(memPoolSize);
     }
+    const bool hasFixedMemPool = allocator.getMemPoolStatus();
     // count the number of times all tensors are used
     std::unordered_map<TensorObj *, size_t> tensorToRefCount;
     // record the memory address offsets of all tensors to be allocated
@@ -184,6 +186,8 @@ void GraphObj::dataMalloc(bool useNaiveAllocator, size_t memPoolSize) {
 
     // reinit allocator
     allocator.init();
+    if (!weightAllocated)
+        allocator.resetWeightPlan();
 
     // record all weight tensors, including weight tensors and kvcache
     // tensors
@@ -210,18 +214,33 @@ void GraphObj::dataMalloc(bool useNaiveAllocator, size_t memPoolSize) {
             }
         }
     }
+    const auto preserveData = [](TensorObj *tensor, const Blob &blob) {
+        if (tensor->hasData() && tensor->getBytes() > 0 &&
+            tensor->getDataBlob()->getBytes() == tensor->getBytes() &&
+            tensor->getDataBlob()->getPtr<void *>() != blob->getPtr<void *>()) {
+            auto copy = tensor->clone();
+            copy->setDataBlob(blob);
+            copy->copyData(tensor);
+        }
+    };
     // if memory has not yet been allocated for weight tensors,
     // allocate memory now and do not allocate again in the future.
     if (!this->weightAllocated) {
-        this->weightAllocated = true;
-        // only allocate once for weight tensors
+        vector<std::pair<TensorObj *, Blob>> weightBlobs;
+        weightBlobs.reserve(weightTensors.size());
         for (auto &tensor : weightTensors) {
             IT_ASSERT(tensorToOffset.find(tensor) != tensorToOffset.end());
-            tensor->setDataBlob(make_ref<BlobObj>(
-                tensor->runtime,
-                static_cast<uint8_t *>(allocator.getWeightPtr()) +
-                    tensorToOffset[tensor]));
+            if (tensor->hasData() &&
+                tensor->getDataBlob()->getBytes() != tensor->getBytes())
+                tensor->freeData();
+            auto blob = allocator.getWeightBlob(tensorToOffset[tensor],
+                                                tensor->getBytes());
+            preserveData(tensor, blob);
+            weightBlobs.emplace_back(tensor, std::move(blob));
         }
+        for (const auto &[tensor, blob] : weightBlobs)
+            tensor->setDataBlob(blob);
+        this->weightAllocated = true;
     }
     // traverse in topological order and simulate memory allocation
     for (auto &op : ops) {
@@ -255,26 +274,69 @@ void GraphObj::dataMalloc(bool useNaiveAllocator, size_t memPoolSize) {
         }
     }
 
-    // perform actual memory allocation for non-weight tensors
+    vector<std::pair<TensorObj *, size_t>> plannedTensorLayout;
+    vector<std::pair<TensorObj *, size_t>> plannedActivationLayout;
+    if (hasFixedMemPool) {
+        plannedTensorLayout.reserve(tensors.size());
+        plannedActivationLayout.reserve(tensors.size() - weightTensors.size());
+        for (const auto &tensor : tensors) {
+            plannedTensorLayout.emplace_back(tensor.get(), tensor->getBytes());
+            if (!tensor->isWeight()) {
+                const auto offset = tensorToOffset.find(tensor.get());
+                IT_ASSERT(offset != tensorToOffset.end());
+                plannedActivationLayout.emplace_back(tensor.get(),
+                                                     offset->second);
+            }
+        }
+        if (fixedPoolLayoutCommitted) {
+            const bool layoutUnchanged =
+                plannedTensorLayout == fixedPoolTensorLayout &&
+                plannedActivationLayout == fixedPoolActivationLayout;
+            IT_ASSERT(layoutUnchanged,
+                      "Fixed memory pool does not support dynamic memory "
+                      "layout changes");
+        }
+    }
+
+    // Invalid old views must not survive a failed physical reallocation.
+    // Fixed-pool layout changes have already been rejected, so this cannot
+    // discard data before reporting that error.
+    for (auto &tensor : tensors) {
+        if (!tensor->isWeight() && tensor->hasData() &&
+            tensor->getDataBlob()->getBytes() != tensor->getBytes())
+            tensor->freeData();
+    }
+
+    // Prepare every view before publishing any of the new addresses.
+    vector<std::pair<TensorObj *, Blob>> activationBlobs;
+    activationBlobs.reserve(tensors.size() - weightTensors.size());
     for (auto &tensor : tensors) {
         if (!tensor->isWeight()) {
             IT_ASSERT(tensorToOffset.find(tensor.get()) !=
                       tensorToOffset.end());
-            tensor->setDataBlob(make_ref<BlobObj>(
-                tensor->runtime, static_cast<uint8_t *>(allocator.getPtr()) +
-                                     tensorToOffset[tensor.get()]));
+            auto blob = allocator.getActivationBlob(
+                tensorToOffset[tensor.get()], tensor->getBytes());
+            if (tensor->getSource() == nullptr)
+                preserveData(tensor.get(), blob);
+            activationBlobs.emplace_back(tensor.get(), std::move(blob));
         }
     }
+    if (hasFixedMemPool && !fixedPoolLayoutCommitted) {
+        fixedPoolTensorLayout = std::move(plannedTensorLayout);
+        fixedPoolActivationLayout = std::move(plannedActivationLayout);
+        fixedPoolLayoutCommitted = true;
+    }
+    for (const auto &[tensor, blob] : activationBlobs)
+        tensor->setDataBlob(blob);
+    ++allocationGeneration;
 }
 
 Tensor GraphObj::cloneKV(Tensor &tensor) {
     auto obj = tensor->clone();
     if (allocator.getMemPoolStatus()) {
         if (tensor->hasData()) {
-            obj->setDataBlob(make_ref<BlobObj>(
-                tensor->runtime,
-                static_cast<uint8_t *>(allocator.getHeapPtr()) +
-                    allocator.heapAlloc(tensor->getBytes())));
+            auto offset = allocator.heapAlloc(tensor->getBytes());
+            obj->setDataBlob(allocator.getHeapBlob(offset, tensor->getBytes()));
             obj->copyData(tensor);
         }
     } else {
@@ -284,6 +346,24 @@ Tensor GraphObj::cloneKV(Tensor &tensor) {
         }
     }
     return obj;
+}
+
+void GraphObj::validateMemory() const {
+    for (const auto &tensor : tensors) {
+        IT_ASSERT(tensor != nullptr, "Graph contains a null tensor");
+        IT_ASSERT(tensor->hasData(), "Tensor " +
+                                         std::to_string(tensor->getFuid()) +
+                                         " has no allocated memory");
+        auto blob = tensor->getDataBlob();
+        IT_ASSERT(blob->getBytes() >= tensor->getBytes(),
+                  "Tensor " + std::to_string(tensor->getFuid()) + " requires " +
+                      std::to_string(tensor->getBytes()) +
+                      " bytes, but its Blob has only " +
+                      std::to_string(blob->getBytes()));
+        IT_ASSERT(blob->getPtr<void *>() != nullptr,
+                  "Tensor " + std::to_string(tensor->getFuid()) +
+                      " has null backing memory");
+    }
 }
 
 void GraphObj::freeHeap() { this->allocator.freeHeap(); }

--- a/src/core/lazy_allocator.cc
+++ b/src/core/lazy_allocator.cc
@@ -1,4 +1,5 @@
 #include "core/lazy_allocator.h"
+#include <limits>
 #include <utility>
 
 namespace infini {
@@ -9,6 +10,11 @@ namespace infini {
 // memory allocation routines from the driver or runtime API is always aligned
 // to at least 256 bytes.
 constexpr size_t alignmentInBytesForCUDA = 256;
+
+static size_t checkedAdd(size_t lhs, size_t rhs, const char *message) {
+    IT_ASSERT(lhs <= std::numeric_limits<size_t>::max() - rhs, message);
+    return lhs + rhs;
+}
 
 LazyAllocator::LazyAllocator(Runtime runtime) : runtime(runtime) {
     if (runtime->isCuda()) {
@@ -23,17 +29,7 @@ LazyAllocator::LazyAllocator(Runtime runtime) : runtime(runtime) {
     }
 }
 
-LazyAllocator::~LazyAllocator() {
-    if (this->ptr != nullptr) {
-        runtime->dealloc(this->ptr);
-    }
-    if (this->weightPtr != nullptr) {
-        runtime->dealloc(this->weightPtr);
-    }
-    if (this->memPoolPtr != nullptr) {
-        runtime->dealloc(this->memPoolPtr);
-    }
-}
+LazyAllocator::~LazyAllocator() = default;
 
 void LazyAllocator::init() {
     used = 0;
@@ -41,18 +37,21 @@ void LazyAllocator::init() {
     freeBlocks.clear();
     headAddrToBlockSize.clear();
     tailAddrToBlockSize.clear();
-    if (this->ptr != nullptr) {
-        runtime->dealloc(this->ptr);
-    }
-    this->ptr = nullptr;
+    this->ptr.reset();
+}
+
+void LazyAllocator::resetWeightPlan() {
+    weightPeak = 0;
+    weightPtr.reset();
 }
 
 void LazyAllocator::setMemPool(size_t memPoolSize) {
     IT_ASSERT(memPoolSize > 0);
     if (!this->hasMemPool) {
+        auto pool = runtime->allocBlob(memPoolSize);
         this->hasMemPool = true;
         this->memPoolSize = memPoolSize;
-        this->memPoolPtr = runtime->alloc(memPoolSize);
+        this->memPoolPtr = std::move(pool);
     }
 }
 
@@ -61,6 +60,8 @@ bool LazyAllocator::getMemPoolStatus() { return this->hasMemPool; }
 size_t LazyAllocator::alloc(size_t size) {
     // pad the size to the multiple of alignment
     size = this->getAlignedSize(size);
+    if (size == 0)
+        return peak;
     auto it = this->freeBlocks.lower_bound(freeBlockInfo{(size_t)0, size});
 
     size_t retAddr = this->peak;
@@ -68,7 +69,7 @@ size_t LazyAllocator::alloc(size_t size) {
         // found an alvailable free memory block for allocation
         size_t blockSize = it->blockSize;
         retAddr = it->addr;
-        size_t tailAddr = retAddr + size;
+        size_t tailAddr = checkedAdd(retAddr, size, "Memory offset overflow");
         // update the map of head and tail address offset of memory blocks
         this->headAddrToBlockSize.erase(retAddr);
         this->tailAddrToBlockSize.erase(tailAddr);
@@ -82,7 +83,8 @@ size_t LazyAllocator::alloc(size_t size) {
         }
         // update the free balanced tree
         this->freeBlocks.erase(it);
-        this->used += tailAddr - retAddr;
+        this->used =
+            checkedAdd(this->used, tailAddr - retAddr, "Used memory overflow");
     } else {
         // the allocated memory space is not sufficient for reallocation, it
         // needs to be extended
@@ -93,16 +95,18 @@ size_t LazyAllocator::alloc(size_t size) {
             // 'peak'
             retAddr = this->peak - blockTailWithPeak->second;
             IT_ASSERT(blockTailWithPeak->second < size);
-            this->peak += (size - blockTailWithPeak->second);
+            this->peak =
+                checkedAdd(this->peak, size - blockTailWithPeak->second,
+                           "Memory peak overflow");
             // updata freeBlocks, headAddrToBlockSize and tailAddrToBlockSize
             freeBlockInfo endBlock = {retAddr, blockTailWithPeak->second};
             this->freeBlocks.erase(endBlock);
             this->headAddrToBlockSize.erase(endBlock.addr);
             this->tailAddrToBlockSize.erase(endBlock.addr + endBlock.blockSize);
         } else {
-            this->peak = this->peak + size;
+            this->peak = checkedAdd(this->peak, size, "Memory peak overflow");
         }
-        this->used += size;
+        this->used = checkedAdd(this->used, size, "Used memory overflow");
     }
 
     return retAddr;
@@ -112,15 +116,19 @@ size_t LazyAllocator::allocWeight(size_t size) {
     IT_ASSERT(this->weightPtr == nullptr);
     size = this->getAlignedSize(size);
     size_t retAddr = this->weightPeak;
-    this->weightPeak += size;
+    this->weightPeak =
+        checkedAdd(this->weightPeak, size, "Weight memory overflow");
     return retAddr;
 }
 
 size_t LazyAllocator::heapAlloc(size_t size) {
     size = this->getAlignedSize(size);
-    this->heapPeak += size;
-    IT_ASSERT(this->memPoolSize >=
-              this->weightPeak + this->peak + this->heapPeak);
+    this->heapPeak = checkedAdd(this->heapPeak, size, "Heap memory overflow");
+    const auto graphPeak =
+        checkedAdd(this->weightPeak, this->peak, "Graph memory overflow");
+    const auto totalPeak =
+        checkedAdd(graphPeak, this->heapPeak, "Total memory overflow");
+    IT_ASSERT(this->memPoolSize >= totalPeak);
     size_t retAddr = this->memPoolSize - this->heapPeak;
     return retAddr;
 }
@@ -130,7 +138,9 @@ void LazyAllocator::freeHeap() { this->heapPeak = 0; }
 void LazyAllocator::free(size_t addr, size_t size) {
     IT_ASSERT(this->ptr == nullptr);
     size = getAlignedSize(size);
-    auto tailAddr = addr + size;
+    if (size == 0)
+        return;
+    auto tailAddr = checkedAdd(addr, size, "Memory offset overflow");
     freeBlockInfo block = {addr, tailAddr - addr};
     this->headAddrToBlockSize[addr] = block.blockSize;
     this->tailAddrToBlockSize[tailAddr] = block.blockSize;
@@ -164,47 +174,78 @@ void LazyAllocator::free(size_t addr, size_t size) {
             freeBlockInfo{tailAddr - subBlockSize, subBlockSize});
     }
     this->freeBlocks.insert(block);
+    IT_ASSERT(this->used >= size, "Freed memory exceeds used memory");
     this->used -= size;
 }
 
 void *LazyAllocator::getPtr() {
     if (!hasMemPool) {
         if (this->ptr == nullptr) {
-            this->ptr = runtime->alloc(this->peak);
+            this->ptr = runtime->allocBlob(this->peak);
             // #ifdef DEBUG_MODE
             //         printf("LazyAllocator really alloc non-weight: %p %lu
             //         bytes\n", this->ptr, peak);
             // #endif
         }
-        return this->ptr;
+        return this->ptr->getPtr<void *>();
     } else {
-        IT_ASSERT(this->memPoolSize >= this->weightPeak + this->peak);
-        return static_cast<uint8_t *>(this->memPoolPtr) + weightPeak;
+        const auto graphPeak =
+            checkedAdd(this->weightPeak, this->peak, "Graph memory overflow");
+        IT_ASSERT(this->memPoolSize >= graphPeak);
+        return static_cast<uint8_t *>(memPoolPtr->getPtr<void *>()) +
+               weightPeak;
     }
+}
+
+Blob LazyAllocator::getActivationBlob(size_t offset, size_t bytes) {
+    getPtr();
+    if (!hasMemPool) {
+        return make_ref<BlobObj>(ptr, offset, bytes);
+    }
+    IT_ASSERT(weightPeak <= memPoolSize);
+    IT_ASSERT(offset <= memPoolSize - weightPeak);
+    return make_ref<BlobObj>(
+        memPoolPtr, checkedAdd(weightPeak, offset, "Memory offset overflow"),
+        bytes);
 }
 
 void *LazyAllocator::getWeightPtr() {
     if (!hasMemPool) {
         if (this->weightPtr == nullptr) {
-            this->weightPtr = runtime->alloc(this->weightPeak);
+            this->weightPtr = runtime->allocBlob(this->weightPeak);
             // #ifdef DEBUG_MODE
             //         printf("LazyAllocator really alloc weight: %p %lu
             //         bytes\n",
             //                this->weightPtr, weightPeak);
             // #endif
         }
-        return this->weightPtr;
+        return this->weightPtr->getPtr<void *>();
     } else {
-        return this->memPoolPtr;
+        return this->memPoolPtr->getPtr<void *>();
     }
+}
+
+Blob LazyAllocator::getWeightBlob(size_t offset, size_t bytes) {
+    getWeightPtr();
+    const auto &storage = hasMemPool ? memPoolPtr : weightPtr;
+    return make_ref<BlobObj>(storage, offset, bytes);
 }
 
 void *LazyAllocator::getHeapPtr() {
     IT_ASSERT(hasMemPool);
-    return this->memPoolPtr;
+    return this->memPoolPtr->getPtr<void *>();
+}
+
+Blob LazyAllocator::getHeapBlob(size_t offset, size_t bytes) {
+    getHeapPtr();
+    return make_ref<BlobObj>(memPoolPtr, offset, bytes);
 }
 
 size_t LazyAllocator::getAlignedSize(size_t size) {
+    if (size == 0)
+        return 0;
+    IT_ASSERT(size <= std::numeric_limits<size_t>::max() - alignment + 1,
+              "Memory alignment overflow");
     return ((size - 1) / this->alignment + 1) * this->alignment;
 }
 

--- a/src/core/runtime.cc
+++ b/src/core/runtime.cc
@@ -1,12 +1,16 @@
 #include "core/runtime.h"
 #include "core/blob.h"
+#include "core/graph.h"
 #include "core/kernel.h"
 #include "core/perf_engine.h"
 #include "utils/data_generator.h"
+#include <algorithm>
 #include <chrono>
 #include <cstring>
 namespace infini {
 void CpuRuntimeObj::run(const Graph &graph, bool tune, bool profiling) const {
+    IT_ASSERT(graph != nullptr, "Cannot run a null graph");
+    graph->validateMemory();
     if (!tune && profiling)
         IT_TODO_HALT();
     const auto &kernelRegistry = KernelRegistry::getInstance();
@@ -60,6 +64,7 @@ void CpuRuntimeObj::run(const Graph &graph, bool tune, bool profiling) const {
 }
 
 double RuntimeObj::getPerfTime(const Graph &graph, bool profiling) const {
+    IT_ASSERT(graph != nullptr, "Cannot profile a null graph");
     const auto &kernelRegistry = KernelRegistry::getInstance();
     auto &perfEngine = PerfEngine::getInstance();
     // Statistics
@@ -80,19 +85,27 @@ double RuntimeObj::getPerfTime(const Graph &graph, bool profiling) const {
             // allocate memory for empty tensors and release it after profiling
             TensorVec allocatedTensors;
             for (auto t : op->getInputs())
-                if (!t->hasData())
+                if (!t->hasData() ||
+                    t->getDataBlob()->getBytes() != t->getBytes())
                     allocatedTensors.emplace_back(t);
             for (auto t : op->getOutputs())
-                if (!t->hasData())
+                if (!t->hasData() ||
+                    t->getDataBlob()->getBytes() != t->getBytes())
                     allocatedTensors.emplace_back(t);
-            for (auto t : allocatedTensors) {
-                t->dataMalloc();
-                t->setData(IncrementalGenerator());
-            }
+            try {
+                for (auto t : allocatedTensors) {
+                    t->dataMalloc();
+                    t->setData(IncrementalGenerator());
+                }
 
-            // Profile operators and record the results
-            record = kernel->tune(op, this);
-            perfEngine.setPerfData(perfKey, record);
+                // Profile operators and record the results
+                record = kernel->tune(op, this);
+                perfEngine.setPerfData(perfKey, record);
+            } catch (...) {
+                for (auto t : allocatedTensors)
+                    t->freeData();
+                throw;
+            }
 
             // Free allocated memory
             for (auto t : allocatedTensors)
@@ -125,7 +138,16 @@ void RuntimeObj::printProfilingData(double totalTime,
 }
 
 Blob RuntimeObj::allocBlob(size_t size) {
-    return make_ref<BlobObj>(shared_from_this(), alloc(size));
+    const auto allocationSize = std::max<size_t>(size, 1);
+    auto ptr = alloc(allocationSize);
+    if (ptr == nullptr)
+        throw std::bad_alloc();
+    try {
+        return make_ref<BlobObj>(shared_from_this(), ptr, size);
+    } catch (...) {
+        dealloc(ptr);
+        throw;
+    }
 }
 
 void RuntimeObj::copyBlob(const TensorObj *dst, const TensorObj *src) const {

--- a/src/core/tensor.cc
+++ b/src/core/tensor.cc
@@ -4,14 +4,35 @@
 #include "core/runtime.h"
 #include "utils/dataloader.h"
 #include <cstring>
+#include <limits>
 #include <numeric>
 
 namespace infini {
 
+namespace {
+size_t getTensorSize(const Shape &shape, DataType dtype) {
+    size_t size = 1;
+    for (const auto dim : shape) {
+        IT_ASSERT(dim >= 0, "Tensor dimensions must be non-negative");
+        if (dim == 0) {
+            size = 0;
+            continue;
+        }
+        IT_ASSERT(size <= std::numeric_limits<size_t>::max() /
+                              static_cast<size_t>(dim),
+                  "Tensor element count overflow");
+        size *= static_cast<size_t>(dim);
+    }
+    IT_ASSERT(dtype.getSize() == 0 ||
+                  size <= std::numeric_limits<size_t>::max() / dtype.getSize(),
+              "Tensor byte size overflow");
+    return size;
+}
+} // namespace
+
 TensorObj::TensorObj(Shape shape_, DataType dtype, Runtime runtime)
     : TensorBaseObj(shape_.size(), dtype, runtime), shape(std::move(shape_)),
-      _size(std::accumulate(shape.begin(), shape.end(), 1, std::multiplies{})) {
-}
+      _size(getTensorSize(shape, dtype)) {}
 
 string TensorObj::toString() const {
     // Convert data pointer to string
@@ -60,9 +81,8 @@ Shape TensorObj::getStride() const {
 }
 
 void TensorObj::setShape(Shape shape_) {
-    shape = shape_;
-    size_t size = std::accumulate(shape.begin(), shape.end(), 1,
-                                  [](auto acc, auto x) { return acc * x; });
+    const auto size = getTensorSize(shape_, dtype);
+    shape = std::move(shape_);
     _size = size;
 }
 
@@ -161,8 +181,10 @@ bool TensorObj::equalData(const Tensor &rhs, double relativeError) const {
 }
 
 void TensorObj::dataMalloc() {
-    if (!data)
+    if (!data || data->getBytes() != getBytes()) {
+        data.reset();
         data = runtime->allocBlob(getBytes());
+    }
 }
 
 void TensorObj::copyData(const TensorObj *src) {

--- a/src/cuda/cuda_runtime.cc
+++ b/src/cuda/cuda_runtime.cc
@@ -20,6 +20,8 @@ void CHECK_CUDA_KERNEL_ERROR(infini::Operator op) {
 
 namespace infini {
 void CudaRuntimeObj::runWithoutSync(const Graph &graph) const {
+    IT_ASSERT(graph != nullptr, "Cannot run a null graph");
+    graph->validateMemory();
     const auto &kernelRegistry = KernelRegistry::getInstance();
     auto &perfEngine = PerfEngine::getInstance();
     for (auto &op : graph->getOperators()) {
@@ -40,7 +42,22 @@ void CudaRuntimeObj::runWithoutSync(const Graph &graph) const {
 }
 
 void CudaRuntimeObj::runWithCudaGraph(const Graph &graph) {
+    IT_ASSERT(graph != nullptr, "Cannot run a null graph");
+    graph->validateMemory();
     if (!isCudaGraphCreated) {
+        vector<const TensorObj *> capturedTensors;
+        vector<const void *> capturedTensorAddresses;
+        vector<vector<int>> capturedTensorShapes;
+        capturedTensors.reserve(graph->getTensors().size());
+        capturedTensorAddresses.reserve(graph->getTensors().size());
+        capturedTensorShapes.reserve(graph->getTensors().size());
+        for (const auto &tensor : graph->getTensors()) {
+            capturedTensors.emplace_back(tensor.get());
+            capturedTensorAddresses.emplace_back(
+                tensor->getRawDataPtr<const void *>());
+            capturedTensorShapes.emplace_back(tensor->getDims());
+        }
+
         CUDAStream::createStream();
         checkCudnnError(cudnnSetStream(cudnn, CUDAStream::getCurrentStream()));
         checkCublasError(
@@ -53,7 +70,30 @@ void CudaRuntimeObj::runWithCudaGraph(const Graph &graph) {
         checkCudaError(
             cudaGraphInstantiate(&cudaGraphInstance, cudaGraph, NULL, NULL, 0));
         isCudaGraphCreated = true;
+        cudaGraphOwner = graph;
+        cudaGraphAllocationGeneration = graph->getAllocationGeneration();
+        cudaGraphTensors = std::move(capturedTensors);
+        cudaGraphTensorAddresses = std::move(capturedTensorAddresses);
+        cudaGraphTensorShapes = std::move(capturedTensorShapes);
     } else {
+        auto owner = cudaGraphOwner.lock();
+        IT_ASSERT(owner && owner.get() == graph.get(),
+                  "CUDA Graph was captured for a different graph");
+        IT_ASSERT(cudaGraphAllocationGeneration ==
+                      graph->getAllocationGeneration(),
+                  "CUDA Graph memory changed after capture; capture a new "
+                  "runtime before replay");
+        const auto &tensors = graph->getTensors();
+        IT_ASSERT(cudaGraphTensors.size() == tensors.size(),
+                  "CUDA Graph tensor set changed after capture");
+        for (size_t i = 0; i < tensors.size(); ++i) {
+            IT_ASSERT(cudaGraphTensors[i] == tensors[i].get() &&
+                          cudaGraphTensorAddresses[i] ==
+                              tensors[i]->getRawDataPtr<const void *>() &&
+                          cudaGraphTensorShapes[i] == tensors[i]->getDims(),
+                      "CUDA Graph tensor memory or shape changed after "
+                      "capture; capture a new runtime before replay");
+        }
         checkCudaError(
             cudaGraphLaunch(cudaGraphInstance, CUDAStream::getCurrentStream()));
     }
@@ -61,6 +101,8 @@ void CudaRuntimeObj::runWithCudaGraph(const Graph &graph) {
 }
 
 void CudaRuntimeObj::tune(const Graph &graph, bool profiling = false) const {
+    IT_ASSERT(graph != nullptr, "Cannot tune a null graph");
+    graph->validateMemory();
     const auto &kernelRegistry = KernelRegistry::getInstance();
     auto &perfEngine = PerfEngine::getInstance();
     double totalTime = 0;

--- a/src/kunlun/kunlun_runtime.cc
+++ b/src/kunlun/kunlun_runtime.cc
@@ -1,4 +1,5 @@
 #include "kunlun/kunlun_runtime.h"
+#include "core/graph.h"
 #include "core/kernel.h"
 #include "core/perf_engine.h"
 
@@ -6,6 +7,8 @@ namespace infini {
 
 void KUNLUNRuntimeObj::runWithoutSync(const Graph &graph, bool tune = false,
                                       bool profiling = false) const {
+    IT_ASSERT(graph != nullptr, "Cannot run a null graph");
+    graph->validateMemory();
     const auto &kernelRegistry = KernelRegistry::getInstance();
     auto &perfEngine = PerfEngine::getInstance();
     double totalTime = 0;

--- a/test/core/test_graph.cc
+++ b/test/core/test_graph.cc
@@ -5,8 +5,72 @@
 #include "operators/matmul.h"
 #include "operators/unary.h"
 #include "test.h"
+#include <cstdlib>
+#include <new>
+#include <unordered_set>
 
 namespace infini {
+
+class TrackingCpuRuntimeObj final : public CpuRuntimeObj {
+  private:
+    std::unordered_set<void *> livePointers;
+    bool failNextAllocation = false;
+    bool failNextDeallocation = false;
+    mutable bool failNextCopy = false;
+    size_t allocationCount = 0;
+    size_t deallocationCount = 0;
+    vector<size_t> allocationSizes;
+
+  public:
+    TrackingCpuRuntimeObj() : CpuRuntimeObj(Device::CPU) {}
+
+    void *alloc(size_t size) override {
+        if (failNextAllocation) {
+            failNextAllocation = false;
+            throw std::bad_alloc();
+        }
+        auto ptr = std::calloc(1, size);
+        if (ptr == nullptr)
+            throw std::bad_alloc();
+        IT_ASSERT(livePointers.insert(ptr).second,
+                  "Allocator returned a live pointer");
+        ++allocationCount;
+        allocationSizes.emplace_back(size);
+        return ptr;
+    }
+
+    void dealloc(void *ptr) override {
+        IT_ASSERT(ptr != nullptr, "Cannot deallocate a null pointer");
+        IT_ASSERT(livePointers.erase(ptr) == 1,
+                  "Pointer was not allocated or was already freed");
+        std::free(ptr);
+        ++deallocationCount;
+        if (failNextDeallocation) {
+            failNextDeallocation = false;
+            throw Exception("Injected deallocation failure");
+        }
+    }
+
+    string toString() const override { return "Tracking CPU Runtime"; }
+
+    void copyBlobInsideRuntime(void *dst, const void *src,
+                               size_t bytes) const override {
+        if (failNextCopy) {
+            failNextCopy = false;
+            IT_ASSERT(false, "Injected copy failure");
+        }
+        CpuRuntimeObj::copyBlobInsideRuntime(dst, src, bytes);
+    }
+
+    void failNextAlloc() { failNextAllocation = true; }
+    void failNextDealloc() { failNextDeallocation = true; }
+    void failNextBlobCopy() { failNextCopy = true; }
+    size_t getLiveAllocationCount() const { return livePointers.size(); }
+    size_t getAllocationCount() const { return allocationCount; }
+    size_t getDeallocationCount() const { return deallocationCount; }
+    const vector<size_t> &getAllocationSizes() const { return allocationSizes; }
+    void clearAllocationSizes() { allocationSizes.clear(); }
+};
 
 TEST(Graph, build_and_run) {
     Runtime runtime = NativeCpuRuntimeObj::getInstance();
@@ -35,6 +99,382 @@ TEST(Graph, build_and_run) {
     ans->dataMalloc();
     ans->copyin(vector<uint32_t>{38, 44, 50, 56, 83, 98, 113, 128});
     EXPECT_TRUE(o0->equalData(ans));
+}
+
+TEST(Graph, naive_allocator_reallocates_dynamic_tensors) {
+    Runtime runtime = NativeCpuRuntimeObj::getInstance();
+    Graph g = make_ref<GraphObj>(runtime);
+    Tensor input = g->addTensor({1, 2}, DataType::Float32);
+    Tensor weight = g->addTensor({2, 2}, DataType::Float32);
+    input->setInput();
+    weight->setWeight();
+    auto matmul = g->addOp<MatmulObj>(input, weight, nullptr);
+    Tensor output = matmul->getOutput();
+    output->setOutput();
+
+    g->dataMalloc(true);
+    auto initialInputBlob = input->getDataBlob();
+    auto initialOutputBlob = output->getDataBlob();
+    auto weightBlob = weight->getDataBlob();
+    weight->copyin(vector<float>{1, 0, 0, 1});
+
+    constexpr int expandedBatch = 8192;
+    input->setShape({expandedBatch, 2});
+    g->shape_infer();
+    g->dataMalloc(true);
+
+    ASSERT_NE(input->getDataBlob(), initialInputBlob);
+    ASSERT_NE(output->getDataBlob(), initialOutputBlob);
+    EXPECT_EQ(weight->getDataBlob(), weightBlob);
+    EXPECT_GE(input->getDataBlob()->getBytes(), input->getBytes());
+    EXPECT_GE(output->getDataBlob()->getBytes(), output->getBytes());
+
+    vector<float> expandedInput(expandedBatch * 2);
+    for (size_t i = 0; i < expandedInput.size(); ++i)
+        expandedInput[i] = static_cast<float>(i);
+    input->copyin(expandedInput);
+    runtime->run(g);
+    EXPECT_TRUE(output->equalData(expandedInput));
+
+    auto expandedInputBlob = input->getDataBlob();
+    auto expandedOutputBlob = output->getDataBlob();
+    input->setShape({3, 2});
+    g->shape_infer();
+    g->dataMalloc(true);
+
+    EXPECT_NE(input->getDataBlob(), expandedInputBlob);
+    EXPECT_NE(output->getDataBlob(), expandedOutputBlob);
+    EXPECT_EQ(weight->getDataBlob(), weightBlob);
+    EXPECT_EQ(input->getDataBlob()->getBytes(), input->getBytes());
+    EXPECT_EQ(output->getDataBlob()->getBytes(), output->getBytes());
+    input->copyin(vector<float>{1, 2, 3, 4, 5, 6});
+    runtime->run(g);
+    EXPECT_TRUE(output->equalData(vector<float>{1, 2, 3, 4, 5, 6}));
+
+    input->setShape({expandedBatch * 2, 2});
+    g->shape_infer();
+    g->dataMalloc(true);
+
+    EXPECT_NE(input->getDataBlob(), expandedInputBlob);
+    EXPECT_NE(output->getDataBlob(), expandedOutputBlob);
+    EXPECT_EQ(weight->getDataBlob(), weightBlob);
+    EXPECT_GE(input->getDataBlob()->getBytes(), input->getBytes());
+    EXPECT_GE(output->getDataBlob()->getBytes(), output->getBytes());
+}
+
+TEST(Graph, lazy_allocator_preserves_preloaded_user_data) {
+    Runtime runtime = NativeCpuRuntimeObj::getInstance();
+    Graph g = make_ref<GraphObj>(runtime);
+    Tensor input = g->addTensor({1, 2}, DataType::Float32);
+    Tensor weight = g->addTensor({2, 2}, DataType::Float32);
+    input->setInput();
+    weight->setWeight();
+
+    input->dataMalloc();
+    input->copyin(vector<float>{3, 4});
+    weight->dataMalloc();
+    weight->copyin(vector<float>{1, 0, 0, 1});
+
+    auto matmul = g->addOp<MatmulObj>(input, weight, nullptr);
+    matmul->getOutput()->setOutput();
+    g->dataMalloc();
+    runtime->run(g);
+
+    EXPECT_TRUE(matmul->getOutput()->equalData(vector<float>{3, 4}));
+}
+
+TEST(Graph, owned_blobs_release_exactly_once) {
+    auto runtime = make_ref<TrackingCpuRuntimeObj>();
+    Tensor tensor =
+        make_ref<TensorObj>(Shape{1, 2}, DataType::Float32, runtime);
+
+    tensor->dataMalloc();
+    EXPECT_EQ(runtime->getLiveAllocationCount(), 1);
+    auto oldBlob = tensor->getDataBlob();
+
+    tensor->setShape({8, 2});
+    tensor->dataMalloc();
+    EXPECT_EQ(runtime->getLiveAllocationCount(), 2);
+    EXPECT_NE(tensor->getDataBlob(), oldBlob);
+
+    oldBlob.reset();
+    EXPECT_EQ(runtime->getLiveAllocationCount(), 1);
+
+    tensor->setShape({2, 2});
+    tensor->dataMalloc();
+    EXPECT_EQ(runtime->getLiveAllocationCount(), 1);
+    EXPECT_EQ(tensor->getDataBlob()->getBytes(), tensor->getBytes());
+
+    {
+        auto clone = tensor->clone(runtime);
+        EXPECT_EQ(runtime->getLiveAllocationCount(), 2);
+    }
+    EXPECT_EQ(runtime->getLiveAllocationCount(), 1);
+
+    {
+        auto temporary = runtime->allocBlob(32);
+        EXPECT_EQ(runtime->getLiveAllocationCount(), 2);
+    }
+    EXPECT_EQ(runtime->getLiveAllocationCount(), 1);
+
+    tensor->freeData();
+    EXPECT_EQ(runtime->getLiveAllocationCount(), 0);
+    EXPECT_EQ(runtime->getAllocationCount(), runtime->getDeallocationCount());
+}
+
+TEST(Graph, blob_destructor_contains_deallocation_exceptions) {
+    auto runtime = make_ref<TrackingCpuRuntimeObj>();
+    auto blob = runtime->allocBlob(32);
+    runtime->failNextDealloc();
+
+    testing::internal::CaptureStderr();
+    blob.reset();
+    const auto error = testing::internal::GetCapturedStderr();
+
+    EXPECT_NE(error.find("Error in ~BlobObj"), string::npos);
+    EXPECT_EQ(runtime->getLiveAllocationCount(), 0);
+    EXPECT_EQ(runtime->getAllocationCount(), runtime->getDeallocationCount());
+}
+
+TEST(Graph, lazy_allocator_views_keep_storage_alive) {
+    auto runtime = make_ref<TrackingCpuRuntimeObj>();
+    {
+        Graph g = make_ref<GraphObj>(runtime);
+        Tensor input = g->addTensor({1, 2}, DataType::Float32);
+        Tensor weight = g->addTensor({2, 2}, DataType::Float32);
+        input->setInput();
+        weight->setWeight();
+        auto matmul = g->addOp<MatmulObj>(input, weight, nullptr);
+        matmul->getOutput()->setOutput();
+
+        g->dataMalloc();
+        EXPECT_EQ(runtime->getLiveAllocationCount(), 2);
+        auto oldInputBlob = input->getDataBlob();
+
+        input->setShape({8192, 2});
+        g->shape_infer();
+        g->dataMalloc();
+        EXPECT_EQ(runtime->getLiveAllocationCount(), 3);
+
+        oldInputBlob.reset();
+        EXPECT_EQ(runtime->getLiveAllocationCount(), 2);
+        g->validateMemory();
+    }
+    EXPECT_EQ(runtime->getLiveAllocationCount(), 0);
+    EXPECT_EQ(runtime->getAllocationCount(), runtime->getDeallocationCount());
+}
+
+TEST(Graph, allocation_failure_leaves_tensor_without_data) {
+    auto runtime = make_ref<TrackingCpuRuntimeObj>();
+    Tensor tensor =
+        make_ref<TensorObj>(Shape{1, 2}, DataType::Float32, runtime);
+    tensor->dataMalloc();
+    tensor->setShape({8192, 2});
+    runtime->failNextAlloc();
+
+    EXPECT_THROW(tensor->dataMalloc(), std::bad_alloc);
+    EXPECT_FALSE(tensor->hasData());
+    EXPECT_EQ(runtime->getLiveAllocationCount(), 0);
+
+    tensor->dataMalloc();
+    EXPECT_TRUE(tensor->hasData());
+    EXPECT_EQ(runtime->getLiveAllocationCount(), 1);
+    tensor->freeData();
+    EXPECT_EQ(runtime->getLiveAllocationCount(), 0);
+}
+
+TEST(Graph, lazy_allocation_failure_leaves_activations_without_data) {
+    auto runtime = make_ref<TrackingCpuRuntimeObj>();
+    {
+        Graph g = make_ref<GraphObj>(runtime);
+        Tensor input = g->addTensor({1, 2}, DataType::Float32);
+        Tensor weight = g->addTensor({2, 2}, DataType::Float32);
+        input->setInput();
+        weight->setWeight();
+        auto matmul = g->addOp<MatmulObj>(input, weight, nullptr);
+        Tensor output = matmul->getOutput();
+        output->setOutput();
+
+        g->dataMalloc();
+        EXPECT_EQ(runtime->getLiveAllocationCount(), 2);
+        input->setShape({8192, 2});
+        g->shape_infer();
+        runtime->failNextAlloc();
+
+        EXPECT_THROW(g->dataMalloc(), std::bad_alloc);
+        EXPECT_FALSE(input->hasData());
+        EXPECT_FALSE(output->hasData());
+        EXPECT_TRUE(weight->hasData());
+        EXPECT_EQ(runtime->getLiveAllocationCount(), 1);
+        EXPECT_THROW(runtime->run(g), Exception);
+
+        g->dataMalloc();
+        EXPECT_TRUE(input->hasData());
+        EXPECT_TRUE(output->hasData());
+        EXPECT_TRUE(weight->hasData());
+        EXPECT_EQ(runtime->getLiveAllocationCount(), 2);
+    }
+    EXPECT_EQ(runtime->getLiveAllocationCount(), 0);
+    EXPECT_EQ(runtime->getAllocationCount(), runtime->getDeallocationCount());
+}
+
+TEST(Graph, lazy_weight_allocation_failure_can_retry) {
+    auto runtime = make_ref<TrackingCpuRuntimeObj>();
+    {
+        Graph g = make_ref<GraphObj>(runtime);
+        Tensor input = g->addTensor({1, 2}, DataType::Float32);
+        Tensor weight = g->addTensor({2, 2}, DataType::Float32);
+        input->setInput();
+        weight->setWeight();
+        auto matmul = g->addOp<MatmulObj>(input, weight, nullptr);
+        matmul->getOutput()->setOutput();
+
+        runtime->failNextAlloc();
+        EXPECT_THROW(g->dataMalloc(), std::bad_alloc);
+        EXPECT_FALSE(input->hasData());
+        EXPECT_FALSE(weight->hasData());
+        EXPECT_FALSE(matmul->getOutput()->hasData());
+        EXPECT_EQ(runtime->getLiveAllocationCount(), 0);
+
+        g->dataMalloc();
+        ASSERT_FALSE(runtime->getAllocationSizes().empty());
+        EXPECT_EQ(runtime->getAllocationSizes().front(), weight->getBytes());
+        EXPECT_TRUE(input->hasData());
+        EXPECT_TRUE(weight->hasData());
+        EXPECT_TRUE(matmul->getOutput()->hasData());
+        EXPECT_EQ(runtime->getLiveAllocationCount(), 2);
+    }
+    EXPECT_EQ(runtime->getLiveAllocationCount(), 0);
+    EXPECT_EQ(runtime->getAllocationCount(), runtime->getDeallocationCount());
+}
+
+TEST(Graph, lazy_weight_copy_failure_can_retry) {
+    auto runtime = make_ref<TrackingCpuRuntimeObj>();
+    {
+        Graph g = make_ref<GraphObj>(runtime);
+        Tensor input = g->addTensor({1, 2}, DataType::Float32);
+        Tensor weight = g->addTensor({2, 2}, DataType::Float32);
+        input->setInput();
+        weight->setWeight();
+        weight->dataMalloc();
+        weight->copyin(vector<float>{1, 0, 0, 1});
+        auto matmul = g->addOp<MatmulObj>(input, weight, nullptr);
+        matmul->getOutput()->setOutput();
+
+        runtime->clearAllocationSizes();
+        runtime->failNextBlobCopy();
+        EXPECT_THROW(g->dataMalloc(), Exception);
+        ASSERT_EQ(runtime->getAllocationSizes().size(), 1);
+        EXPECT_EQ(runtime->getAllocationSizes()[0], weight->getBytes());
+        EXPECT_TRUE(weight->equalData(vector<float>{1, 0, 0, 1}));
+        EXPECT_EQ(runtime->getLiveAllocationCount(), 2);
+
+        g->dataMalloc();
+        ASSERT_GE(runtime->getAllocationSizes().size(), 3);
+        EXPECT_EQ(runtime->getAllocationSizes()[1], weight->getBytes());
+        EXPECT_TRUE(weight->equalData(vector<float>{1, 0, 0, 1}));
+        EXPECT_TRUE(input->hasData());
+        EXPECT_TRUE(matmul->getOutput()->hasData());
+        EXPECT_EQ(runtime->getLiveAllocationCount(), 2);
+    }
+    EXPECT_EQ(runtime->getLiveAllocationCount(), 0);
+    EXPECT_EQ(runtime->getAllocationCount(), runtime->getDeallocationCount());
+}
+
+TEST(Graph, fixed_pool_rejects_dynamic_layout_changes) {
+    auto runtime = make_ref<TrackingCpuRuntimeObj>();
+    {
+        Graph g = make_ref<GraphObj>(runtime);
+        Tensor a = g->addTensor({4}, DataType::Float32);
+        Tensor b = g->addTensor({4}, DataType::Float32);
+        Tensor c = g->addTensor({4}, DataType::Float32);
+        a->setInput();
+        b->setInput();
+        c->setInput();
+
+        g->dataMalloc(false, 1024);
+        a->copyin(vector<float>{1, 2, 3, 4});
+        b->copyin(vector<float>{10, 20, 30, 40});
+        c->copyin(vector<float>{100, 200, 300, 400});
+
+        g->dataMalloc(false, 1024);
+        EXPECT_TRUE(a->equalData(vector<float>{1, 2, 3, 4}));
+        EXPECT_TRUE(b->equalData(vector<float>{10, 20, 30, 40}));
+        EXPECT_TRUE(c->equalData(vector<float>{100, 200, 300, 400}));
+
+        a->setShape({8});
+        EXPECT_THROW(g->dataMalloc(false, 1024), Exception);
+        EXPECT_TRUE(b->equalData(vector<float>{10, 20, 30, 40}));
+        EXPECT_TRUE(c->equalData(vector<float>{100, 200, 300, 400}));
+
+        a->setShape({4});
+        g->dataMalloc(false, 1024);
+        EXPECT_TRUE(a->equalData(vector<float>{1, 2, 3, 4}));
+        EXPECT_TRUE(b->equalData(vector<float>{10, 20, 30, 40}));
+        EXPECT_TRUE(c->equalData(vector<float>{100, 200, 300, 400}));
+        EXPECT_EQ(runtime->getLiveAllocationCount(), 1);
+    }
+    EXPECT_EQ(runtime->getLiveAllocationCount(), 0);
+    EXPECT_EQ(runtime->getAllocationCount(), runtime->getDeallocationCount());
+}
+
+TEST(Graph, runtime_rejects_unallocated_graph) {
+    auto runtime = make_ref<TrackingCpuRuntimeObj>();
+    Graph nullGraph;
+    EXPECT_THROW(runtime->run(nullGraph), Exception);
+
+    Graph g = make_ref<GraphObj>(runtime);
+    Tensor input = g->addTensor({1, 2}, DataType::Float32);
+    Tensor weight = g->addTensor({2, 2}, DataType::Float32);
+    input->setInput();
+    weight->setWeight();
+    g->addOp<MatmulObj>(input, weight, nullptr);
+
+    EXPECT_THROW(runtime->run(g), Exception);
+    EXPECT_EQ(runtime->getLiveAllocationCount(), 0);
+}
+
+TEST(Graph, profiling_temporary_buffers_release_after_dynamic_shape) {
+    auto runtime = make_ref<TrackingCpuRuntimeObj>();
+    {
+        Graph g = make_ref<GraphObj>(runtime);
+        Tensor input = g->addTensor({1, 41}, DataType::Float32);
+        Tensor weight = g->addTensor({41, 43}, DataType::Float32);
+        input->setInput();
+        weight->setWeight();
+        auto matmul = g->addOp<MatmulObj>(input, weight, nullptr);
+        Tensor output = matmul->getOutput();
+        output->setOutput();
+        g->dataMalloc(true);
+
+        input->setShape({37, 41});
+        g->shape_infer();
+        EXPECT_GT(runtime->getPerfTime(g), 0);
+
+        EXPECT_FALSE(input->hasData());
+        EXPECT_FALSE(output->hasData());
+        EXPECT_TRUE(weight->hasData());
+        EXPECT_EQ(runtime->getLiveAllocationCount(), 1);
+    }
+    EXPECT_EQ(runtime->getLiveAllocationCount(), 0);
+    EXPECT_EQ(runtime->getAllocationCount(), runtime->getDeallocationCount());
+}
+
+TEST(Graph, tensor_shape_allocation_safety) {
+    auto runtime = make_ref<TrackingCpuRuntimeObj>();
+    EXPECT_THROW(make_ref<TensorObj>(Shape{1, -1}, DataType::Float32, runtime),
+                 Exception);
+    EXPECT_THROW(make_ref<TensorObj>(Shape{INT32_MAX, INT32_MAX, INT32_MAX},
+                                     DataType::Float32, runtime),
+                 Exception);
+
+    auto empty = make_ref<TensorObj>(Shape{0, 2}, DataType::Float32, runtime);
+    empty->dataMalloc();
+    EXPECT_EQ(empty->getBytes(), 0);
+    EXPECT_EQ(empty->getDataBlob()->getBytes(), 0);
+    EXPECT_NE(empty->getRawDataPtr<void *>(), nullptr);
+    empty->freeData();
+    EXPECT_EQ(runtime->getLiveAllocationCount(), 0);
 }
 
 TEST(Graph, topological) {

--- a/test/cuda/test_cudagraph.cc
+++ b/test/cuda/test_cudagraph.cc
@@ -57,6 +57,24 @@ TEST(TestCudaRuntime, CudaGraph) {
     cudaRuntime->runWithCudaGraph(gCuda);
     cudaRuntime->runWithCudaGraph(gCuda);
 
+    const auto capturedGeneration = gCuda->getAllocationGeneration();
+    const auto capturedShape = input_q_d->getDims();
+    input_q_d->setShape({1, 1, 2, 64});
+    EXPECT_EQ(gCuda->getAllocationGeneration(), capturedGeneration);
+    EXPECT_THROW(cudaRuntime->runWithCudaGraph(gCuda), Exception);
+    input_q_d->setShape(capturedShape);
+    EXPECT_NO_THROW(cudaRuntime->runWithCudaGraph(gCuda));
+
+    const auto capturedBlob = input_q_d->getDataBlob();
+    const auto capturedAddress = input_q_d->getRawDataPtr<const void *>();
+    input_q_d->freeData();
+    input_q_d->dataMalloc();
+    EXPECT_EQ(gCuda->getAllocationGeneration(), capturedGeneration);
+    EXPECT_NE(input_q_d->getRawDataPtr<const void *>(), capturedAddress);
+    EXPECT_THROW(cudaRuntime->runWithCudaGraph(gCuda), Exception);
+    input_q_d->setDataBlob(capturedBlob);
+    EXPECT_NO_THROW(cudaRuntime->runWithCudaGraph(gCuda));
+
     cudaDeviceSynchronize();
     cudaEventRecord(start);
     cudaRuntime->runWithCudaGraph(gCuda);
@@ -65,6 +83,10 @@ TEST(TestCudaRuntime, CudaGraph) {
     cudaEventElapsedTime(&milliseconds_2, start, stop);
     printf("with cudaGraph, latency: %f ms\n", milliseconds_2);
     EXPECT_GE(milliseconds_1, milliseconds_2);
+
+    // Reallocating graph memory invalidates the addresses captured above.
+    gCuda->dataMalloc();
+    EXPECT_THROW(cudaRuntime->runWithCudaGraph(gCuda), Exception);
 }
 
 } // namespace infini

--- a/test/kernels/cuda/test_cuda_matmul.cc
+++ b/test/kernels/cuda/test_cuda_matmul.cc
@@ -73,12 +73,12 @@ TEST(cuBLAS_Matmul, tune) {
     Graph g = make_ref<GraphObj>(cudaRuntime);
     auto a = g->addTensor(transA ? Shape{B, K, M} : Shape{B, M, K});
     auto b = g->addTensor(transB ? Shape{B, N, K} : Shape{B, K, N});
-    // allocate CUDA memory
+
+    auto matmul = g->addOp<MatmulObj>(a, b, nullptr, transA, transB);
+    // Allocate after the graph is complete so the output is included.
     g->dataMalloc();
     a->setData(IncrementalGenerator());
     b->setData(IncrementalGenerator());
-
-    auto matmul = g->addOp<MatmulObj>(a, b, nullptr, transA, transB);
     matmul->print();
     double time = cudaRuntime->getPerfTime(g);
     EXPECT_GT(time, 1e-3);


### PR DESCRIPTION
## 背景

InfiniTensor 在 Tensor shape 发生变化后，原有内存分配逻辑无法可靠处理容量变化，可能出现以下问题：

- Tensor 继续使用容量不足的旧内存，导致越界访问。
- 独立 Blob 和 NaiveAllocator 重分配后，旧内存无法正确释放。
- LazyAllocator 的内存池切片缺少明确的所有权和容量信息。
- 分配或数据复制失败后，Graph 可能处于不完整状态。
- CUDA Graph 可能 replay 已失效的 Tensor 地址或 shape。

## 修改内容

- 为 Blob 增加容量记录，并通过 owning Blob 和 view Blob 管理独立内存及内存池切片。
- Blob 最后一个 owning 引用销毁时自动调用 Runtime 释放内存。
- Tensor shape 变化后，根据当前字节数重新分配内存，同时处理扩大和缩小。
- NaiveAllocator 保留已分配权重，并安全地重新分配 activation。
- LazyAllocator 使用 Blob 管理 weight、activation 和 fixed memory pool 的生命周期。
- 重建内存池时保留 initializer 和预加载输入数据。
- 增加负维度、元素数量、字节数、offset 和内存对齐溢出检查。
- 分配或复制失败后保持可恢复状态，允许后续重新执行内存分配。
- Runtime 执行前验证 Tensor 是否已分配、容量是否足够以及指针是否有效。
- fixed memory pool 的布局发生变化时明确拒绝执行，避免静默数据覆盖。
- CUDA Graph capture 记录 Graph generation、Tensor 对象、地址和 shape；状态变化后拒绝 replay，避免使用旧地址或参数。

## 动态 Shape 支持

普通 CPU 和 CUDA 执行现在可以安全处理模型输入 shape 的多次变化，包括：

- batch size 扩大和缩小。
- Tensor 容量不足时重新分配。
- LazyAllocator 和 NaiveAllocator 两种分配模式。
- 重新分配后保持 initializer 数据正确。
- 多次动态 shape 执行后的内存正确释放。

## 当前边界

- CUDA Graph capture 后发生 shape 或地址变化时会明确拒绝 replay，暂不自动重新 capture。
- fixed memory pool 暂不支持动态布局变化。
- LazyAllocator 当前仍会在动态 shape 后重新规划并重建 activation pool；高水位复用等性能优化后续单独实现。
- 算子自身的动态 shape 推导和 kernel 支持范围不在本 PR 中扩展。

## 测试结果

- CPU CTest：41/41 通过。
- CUDA CTest：78/78 通过。
- CPU Python ONNX：20 个测试通过，1 个 CUDA 测试跳过。
- CUDA Python ONNX：21 个测试及 10 个子测试通过。
- ASan/LSan：通过，未发现内存泄漏或非法访问。
- compute-sanitizer：0 errors，0 leaks。
- clang-format 14：通过。
- git diff --check：通过。