### PR TITLE
Improve dynamic shape memory reuse

### DIFF
--- a/include/core/graph.h
+++ b/include/core/graph.h
@@ -71,6 +71,8 @@ class GraphObj : public Object {
 
     void dataMalloc(bool useNaiveAllocator = false, size_t memPoolSize = 0);
 
+    void trimMemory();
+
     void validateMemory() const;
 
     size_t getAllocationGeneration() const { return allocationGeneration; }
@@ -124,6 +126,20 @@ class GraphObj : public Object {
     bool checkValid() const;
 
   private:
+    enum class AllocationMode {
+        Uninitialized,
+        Naive,
+        DynamicPool,
+        FixedPool,
+    };
+
+    void dataMallocImpl(bool useNaiveAllocator, size_t memPoolSize, bool trim);
+
+    void dataMallocImplCore(bool useNaiveAllocator, size_t memPoolSize,
+                            bool trim);
+
+    void lockAllocationMode(bool useNaiveAllocator, size_t memPoolSize);
+
     /**
      * @brief Add reverse connections and Op relationship in ctor.
      */
@@ -138,6 +154,9 @@ class GraphObj : public Object {
      * @brief If the weight tensors are allocated.
      */
     bool weightAllocated = false;
+
+    AllocationMode allocationMode = AllocationMode::Uninitialized;
+    size_t fixedPoolSize = 0;
 
     /**
      * @brief Incremented after each successful memory layout update.

--- a/include/core/graph_handler.h
+++ b/include/core/graph_handler.h
@@ -139,6 +139,8 @@ class GraphHandlerObj {
         g->dataMalloc(useNaiveAllocator, memPoolSize);
     }
 
+    inline void trim_memory() { g->trimMemory(); }
+
     inline Tensor clone_KV(Tensor &tensor) { return g->cloneKV(tensor); }
 
     inline void free_heap() { g->freeHeap(); }

--- a/include/core/lazy_allocator.h
+++ b/include/core/lazy_allocator.h
@@ -43,6 +43,10 @@ class LazyAllocator {
     // memory pool ptr
     Blob memPoolPtr;
 
+    // Weak references prevent heap offsets from being reused while a cloned
+    // tensor still points into the fixed memory pool.
+    vector<WRef<BlobObj>> heapBlobs;
+
     // // a cache designed for a batch size that has already occurred
     // std::unordered_map<size_t, std::unordered_map<TensorObj *, size_t>>
     // batchsizeToTensorOffset;
@@ -77,6 +81,8 @@ class LazyAllocator {
 
     void init();
 
+    void reset();
+
     void resetWeightPlan();
 
     void setMemPool(size_t memPoolSize);
@@ -93,7 +99,11 @@ class LazyAllocator {
 
     size_t heapAlloc(size_t size);
 
+    void rollbackHeap(size_t previousPeak);
+
     void freeHeap();
+
+    bool hasLiveHeapBlobs();
 
     // function: simulate memory free
     // arguments:
@@ -105,11 +115,23 @@ class LazyAllocator {
     // return: pointer to the head address of the allocated memory
     void *getPtr();
 
+    Blob prepareActivationStorage(bool exactCapacity = false,
+                                  bool forceNewStorage = false);
+
+    void commitActivationStorage(const Blob &storage);
+
+    bool isCurrentActivationStorage(const Blob &storage) const;
+
+    size_t getHeapPeak() const { return heapPeak; }
+
     // void addCache(size_t batchsize, std::unordered_map<TensorObj *, size_t>);
 
     // std::unordered_map<TensorObj *, size_t> getCache(size_t batchsize);
 
     Blob getActivationBlob(size_t offset, size_t bytes);
+
+    Blob getActivationBlob(const Blob &storage, size_t offset,
+                           size_t bytes) const;
 
     void *getWeightPtr();
 

--- a/pyinfinitensor/src/pyinfinitensor/onnx.py
+++ b/pyinfinitensor/src/pyinfinitensor/onnx.py
@@ -1498,6 +1498,9 @@ class OnnxStub:
     def free_heap(self) -> None:
         self.handler.free_heap()
 
+    def trim_memory(self) -> None:
+        self.handler.trim_memory()
+
     def set_input(self, inputShapes: List[Sequence[int]]) -> None:
         if len(inputShapes) != len(self.inputs):
             raise ValueError(

--- a/pyinfinitensor/tests/test_onnxstub.py
+++ b/pyinfinitensor/tests/test_onnxstub.py
@@ -160,6 +160,13 @@ class TestOnnxStubImport(unittest.TestCase):
                         batch, 2
                     )
                     np.testing.assert_allclose(actual, x @ weight)
+                if not use_naive_allocator:
+                    stub.trim_memory()
+                    stub.run()
+                    actual = np.asarray(stub.outputs["y"].copyout_float()).reshape(
+                        3, 2
+                    )
+                    np.testing.assert_allclose(actual, x @ weight)
 
 
 class TestStaticOnnxInputs(unittest.TestCase):
@@ -475,6 +482,13 @@ class TestOnnxStubCuda(unittest.TestCase):
                     stub.run()
                     actual = np.asarray(stub.outputs["y"].copyout_float()).reshape(
                         batch, 2
+                    )
+                    np.testing.assert_allclose(actual, x @ weight, rtol=1e-5, atol=1e-6)
+                if not use_naive_allocator:
+                    stub.trim_memory()
+                    stub.run()
+                    actual = np.asarray(stub.outputs["y"].copyout_float()).reshape(
+                        2, 2
                     )
                     np.testing.assert_allclose(actual, x @ weight, rtol=1e-5, atol=1e-6)
 

--- a/src/core/graph.cc
+++ b/src/core/graph.cc
@@ -155,10 +155,104 @@ void GraphObj::shape_infer() {
     }
 }
 
+void GraphObj::lockAllocationMode(bool useNaiveAllocator, size_t memPoolSize) {
+    AllocationMode requestedMode;
+    if (useNaiveAllocator) {
+        IT_ASSERT(memPoolSize == 0,
+                  "Naive allocator cannot use a fixed memory pool");
+        requestedMode = AllocationMode::Naive;
+    } else if (memPoolSize > 0 || allocationMode == AllocationMode::FixedPool) {
+        requestedMode = AllocationMode::FixedPool;
+    } else {
+        requestedMode = AllocationMode::DynamicPool;
+    }
+
+    if (allocationMode == AllocationMode::Uninitialized) {
+        allocationMode = requestedMode;
+        if (requestedMode == AllocationMode::FixedPool)
+            fixedPoolSize = memPoolSize;
+        return;
+    }
+
+    IT_ASSERT(allocationMode == requestedMode,
+              "Cannot change allocator mode after the first allocation");
+    if (requestedMode == AllocationMode::FixedPool && memPoolSize > 0) {
+        IT_ASSERT(memPoolSize == fixedPoolSize,
+                  "Cannot change fixed memory pool size after allocation");
+    }
+}
+
 void GraphObj::dataMalloc(bool useNaiveAllocator, size_t memPoolSize) {
+    dataMallocImpl(useNaiveAllocator, memPoolSize, false);
+}
+
+void GraphObj::trimMemory() {
+    IT_ASSERT(allocationMode == AllocationMode::DynamicPool,
+              "trimMemory requires an allocated dynamic memory pool");
+    IT_ASSERT(!allocator.hasLiveHeapBlobs(),
+              "Cannot trim memory while heap tensors are still alive");
+    dataMallocImpl(false, 0, true);
+}
+
+void GraphObj::dataMallocImpl(bool useNaiveAllocator, size_t memPoolSize,
+                              bool trim) {
+    if (allocationMode != AllocationMode::Uninitialized) {
+        dataMallocImplCore(useNaiveAllocator, memPoolSize, trim);
+        return;
+    }
+
+    vector<Blob> previousData;
+    previousData.reserve(tensors.size());
+    for (const auto &tensor : tensors)
+        previousData.emplace_back(tensor->getDataBlob());
+
+    const auto previousGeneration = allocationGeneration;
+    try {
+        dataMallocImplCore(useNaiveAllocator, memPoolSize, trim);
+    } catch (...) {
+        for (size_t i = 0; i < tensors.size(); ++i)
+            tensors[i]->setDataBlob(previousData[i]);
+        allocator.reset();
+        allocationMode = AllocationMode::Uninitialized;
+        fixedPoolSize = 0;
+        weightAllocated = false;
+        fixedPoolLayoutCommitted = false;
+        fixedPoolTensorLayout.clear();
+        fixedPoolActivationLayout.clear();
+        allocationGeneration = previousGeneration;
+        throw;
+    }
+}
+
+void GraphObj::dataMallocImplCore(bool useNaiveAllocator, size_t memPoolSize,
+                                  bool trim) {
     // topological sorting first
 
     IT_ASSERT(topo_sort() == true);
+    lockAllocationMode(useNaiveAllocator, memPoolSize);
+
+    using TensorMemoryState = std::pair<const void *, size_t>;
+    const auto getTensorMemoryState = [](const Tensor &tensor) {
+        if (!tensor->hasData())
+            return TensorMemoryState{nullptr, 0};
+        return TensorMemoryState{tensor->getRawDataPtr<const void *>(),
+                                 tensor->getDataBlob()->getBytes()};
+    };
+    vector<TensorMemoryState> previousMemoryStates;
+    previousMemoryStates.reserve(tensors.size());
+    for (const auto &tensor : tensors)
+        previousMemoryStates.emplace_back(getTensorMemoryState(tensor));
+    const auto updateAllocationGeneration = [&]() {
+        bool changed = previousMemoryStates.size() != tensors.size();
+        for (size_t i = 0; !changed && i < tensors.size(); ++i) {
+            if (previousMemoryStates[i] != getTensorMemoryState(tensors[i])) {
+                changed = true;
+            }
+        }
+        if (changed)
+            ++allocationGeneration;
+    };
+
     if (useNaiveAllocator) {
         // can not set memory pool when use naive allocator
         IT_ASSERT(memPoolSize == 0);
@@ -172,11 +266,11 @@ void GraphObj::dataMalloc(bool useNaiveAllocator, size_t memPoolSize) {
             }
         }
         weightAllocated = true;
-        ++allocationGeneration;
+        updateAllocationGeneration();
         return;
     }
-    if (memPoolSize > 0) {
-        allocator.setMemPool(memPoolSize);
+    if (allocationMode == AllocationMode::FixedPool) {
+        allocator.setMemPool(fixedPoolSize);
     }
     const bool hasFixedMemPool = allocator.getMemPoolStatus();
     // count the number of times all tensors are used
@@ -298,29 +392,65 @@ void GraphObj::dataMalloc(bool useNaiveAllocator, size_t memPoolSize) {
         }
     }
 
-    // Invalid old views must not survive a failed physical reallocation.
-    // Fixed-pool layout changes have already been rejected, so this cannot
-    // discard data before reporting that error.
-    for (auto &tensor : tensors) {
-        if (!tensor->isWeight() && tensor->hasData() &&
-            tensor->getDataBlob()->getBytes() != tensor->getBytes())
-            tensor->freeData();
+    const auto clearInvalidActivationData = [&]() {
+        for (auto &tensor : tensors) {
+            if (!tensor->isWeight() && tensor->hasData() &&
+                tensor->getDataBlob()->getBytes() != tensor->getBytes())
+                tensor->freeData();
+        }
+    };
+
+    Blob activationStorage;
+    try {
+        activationStorage = allocator.prepareActivationStorage(trim);
+    } catch (...) {
+        // Never leave an undersized view available to a later kernel launch.
+        clearInvalidActivationData();
+        throw;
+    }
+    clearInvalidActivationData();
+
+    using TensorBlobPair = std::pair<TensorObj *, Blob>;
+    const auto prepareActivationBlobs = [&](const Blob &storage) {
+        vector<TensorBlobPair> blobs;
+        blobs.reserve(tensors.size() - weightTensors.size());
+        bool movesPreservedData = false;
+        for (auto &tensor : tensors) {
+            if (tensor->isWeight())
+                continue;
+            const auto offset = tensorToOffset.find(tensor.get());
+            IT_ASSERT(offset != tensorToOffset.end());
+            auto blob = allocator.getActivationBlob(storage, offset->second,
+                                                    tensor->getBytes());
+            if (tensor->getSource() == nullptr && tensor->hasData() &&
+                tensor->getDataBlob()->getBytes() == tensor->getBytes() &&
+                tensor->getDataBlob()->getPtr<void *>() !=
+                    blob->getPtr<void *>()) {
+                movesPreservedData = true;
+            }
+            blobs.emplace_back(tensor.get(), std::move(blob));
+        }
+        return std::make_pair(std::move(blobs), movesPreservedData);
+    };
+
+    auto [activationBlobs, movesPreservedData] =
+        prepareActivationBlobs(activationStorage);
+    if (!hasFixedMemPool && movesPreservedData &&
+        allocator.isCurrentActivationStorage(activationStorage)) {
+        // Moving live inputs inside the same pool can overwrite another input
+        // before it is copied. Use a separate candidate storage in this rare
+        // layout-changing case and preserve the transaction boundary.
+        activationBlobs.clear();
+        activationStorage = allocator.prepareActivationStorage(trim, true);
+        activationBlobs = prepareActivationBlobs(activationStorage).first;
     }
 
-    // Prepare every view before publishing any of the new addresses.
-    vector<std::pair<TensorObj *, Blob>> activationBlobs;
-    activationBlobs.reserve(tensors.size() - weightTensors.size());
-    for (auto &tensor : tensors) {
-        if (!tensor->isWeight()) {
-            IT_ASSERT(tensorToOffset.find(tensor.get()) !=
-                      tensorToOffset.end());
-            auto blob = allocator.getActivationBlob(
-                tensorToOffset[tensor.get()], tensor->getBytes());
-            if (tensor->getSource() == nullptr)
-                preserveData(tensor.get(), blob);
-            activationBlobs.emplace_back(tensor.get(), std::move(blob));
-        }
+    for (const auto &[tensor, blob] : activationBlobs) {
+        if (tensor->getSource() == nullptr)
+            preserveData(tensor, blob);
     }
+
+    allocator.commitActivationStorage(activationStorage);
     if (hasFixedMemPool && !fixedPoolLayoutCommitted) {
         fixedPoolTensorLayout = std::move(plannedTensorLayout);
         fixedPoolActivationLayout = std::move(plannedActivationLayout);
@@ -328,16 +458,25 @@ void GraphObj::dataMalloc(bool useNaiveAllocator, size_t memPoolSize) {
     }
     for (const auto &[tensor, blob] : activationBlobs)
         tensor->setDataBlob(blob);
-    ++allocationGeneration;
+    updateAllocationGeneration();
 }
 
 Tensor GraphObj::cloneKV(Tensor &tensor) {
     auto obj = tensor->clone();
     if (allocator.getMemPoolStatus()) {
         if (tensor->hasData()) {
-            auto offset = allocator.heapAlloc(tensor->getBytes());
-            obj->setDataBlob(allocator.getHeapBlob(offset, tensor->getBytes()));
-            obj->copyData(tensor);
+            const auto previousHeapPeak = allocator.getHeapPeak();
+            try {
+                auto offset = allocator.heapAlloc(tensor->getBytes());
+                obj->setDataBlob(
+                    allocator.getHeapBlob(offset, tensor->getBytes()));
+                obj->copyData(tensor);
+            } catch (...) {
+                obj->freeData();
+                allocator.rollbackHeap(previousHeapPeak);
+                throw;
+            }
+            ++allocationGeneration;
         }
     } else {
         if (tensor->hasData()) {
@@ -366,7 +505,12 @@ void GraphObj::validateMemory() const {
     }
 }
 
-void GraphObj::freeHeap() { this->allocator.freeHeap(); }
+void GraphObj::freeHeap() {
+    const bool changed = allocator.getHeapPeak() != 0;
+    allocator.freeHeap();
+    if (changed)
+        ++allocationGeneration;
+}
 
 Tensor GraphObj::addTensor(Shape dim, DataType dtype) {
     return tensors.emplace_back(make_ref<TensorObj>(dim, dtype, runtime));

--- a/src/core/lazy_allocator.cc
+++ b/src/core/lazy_allocator.cc
@@ -1,4 +1,5 @@
 #include "core/lazy_allocator.h"
+#include <algorithm>
 #include <limits>
 #include <utility>
 
@@ -37,7 +38,18 @@ void LazyAllocator::init() {
     freeBlocks.clear();
     headAddrToBlockSize.clear();
     tailAddrToBlockSize.clear();
-    this->ptr.reset();
+}
+
+void LazyAllocator::reset() {
+    init();
+    weightPeak = 0;
+    heapPeak = 0;
+    hasMemPool = false;
+    memPoolSize = 0;
+    ptr.reset();
+    weightPtr.reset();
+    memPoolPtr.reset();
+    heapBlobs.clear();
 }
 
 void LazyAllocator::resetWeightPlan() {
@@ -123,20 +135,38 @@ size_t LazyAllocator::allocWeight(size_t size) {
 
 size_t LazyAllocator::heapAlloc(size_t size) {
     size = this->getAlignedSize(size);
-    this->heapPeak = checkedAdd(this->heapPeak, size, "Heap memory overflow");
+    const auto newHeapPeak =
+        checkedAdd(this->heapPeak, size, "Heap memory overflow");
     const auto graphPeak =
         checkedAdd(this->weightPeak, this->peak, "Graph memory overflow");
     const auto totalPeak =
-        checkedAdd(graphPeak, this->heapPeak, "Total memory overflow");
-    IT_ASSERT(this->memPoolSize >= totalPeak);
-    size_t retAddr = this->memPoolSize - this->heapPeak;
-    return retAddr;
+        checkedAdd(graphPeak, newHeapPeak, "Total memory overflow");
+    IT_ASSERT(this->memPoolSize >= totalPeak,
+              "Fixed memory pool capacity is insufficient for heap data");
+    this->heapPeak = newHeapPeak;
+    return this->memPoolSize - this->heapPeak;
 }
 
-void LazyAllocator::freeHeap() { this->heapPeak = 0; }
+void LazyAllocator::rollbackHeap(size_t previousPeak) {
+    IT_ASSERT(previousPeak <= heapPeak, "Invalid heap rollback position");
+    heapPeak = previousPeak;
+}
+
+bool LazyAllocator::hasLiveHeapBlobs() {
+    heapBlobs.erase(
+        std::remove_if(heapBlobs.begin(), heapBlobs.end(),
+                       [](const auto &blob) { return blob.expired(); }),
+        heapBlobs.end());
+    return !heapBlobs.empty();
+}
+
+void LazyAllocator::freeHeap() {
+    IT_ASSERT(!hasLiveHeapBlobs(),
+              "Cannot free heap while heap tensors are still alive");
+    this->heapPeak = 0;
+}
 
 void LazyAllocator::free(size_t addr, size_t size) {
-    IT_ASSERT(this->ptr == nullptr);
     size = getAlignedSize(size);
     if (size == 0)
         return;
@@ -179,33 +209,73 @@ void LazyAllocator::free(size_t addr, size_t size) {
 }
 
 void *LazyAllocator::getPtr() {
-    if (!hasMemPool) {
-        if (this->ptr == nullptr) {
-            this->ptr = runtime->allocBlob(this->peak);
-            // #ifdef DEBUG_MODE
-            //         printf("LazyAllocator really alloc non-weight: %p %lu
-            //         bytes\n", this->ptr, peak);
-            // #endif
-        }
-        return this->ptr->getPtr<void *>();
-    } else {
+    auto storage = prepareActivationStorage();
+    commitActivationStorage(storage);
+    if (hasMemPool)
+        return static_cast<uint8_t *>(storage->getPtr<void *>()) + weightPeak;
+    return storage->getPtr<void *>();
+}
+
+Blob LazyAllocator::prepareActivationStorage(bool exactCapacity,
+                                             bool forceNewStorage) {
+    if (hasMemPool) {
         const auto graphPeak =
-            checkedAdd(this->weightPeak, this->peak, "Graph memory overflow");
-        IT_ASSERT(this->memPoolSize >= graphPeak);
-        return static_cast<uint8_t *>(memPoolPtr->getPtr<void *>()) +
-               weightPeak;
+            checkedAdd(weightPeak, peak, "Graph memory overflow");
+        const auto totalPeak =
+            checkedAdd(graphPeak, heapPeak, "Total memory overflow");
+        IT_ASSERT(memPoolSize >= totalPeak,
+                  "Fixed memory pool capacity is insufficient");
+        return memPoolPtr;
+    }
+
+    const auto currentCapacity = ptr ? ptr->getBytes() : 0;
+    if (!forceNewStorage && ptr &&
+        ((!exactCapacity && peak <= currentCapacity) ||
+         (exactCapacity && peak == currentCapacity)))
+        return ptr;
+
+    size_t newCapacity = peak;
+    if (forceNewStorage) {
+        newCapacity = std::max(newCapacity, currentCapacity);
+    } else if (!exactCapacity && currentCapacity > 0) {
+        const auto grownCapacity =
+            checkedAdd(currentCapacity, currentCapacity / 2,
+                       "Activation pool capacity overflow");
+        newCapacity = std::max(newCapacity, grownCapacity);
+    }
+    return runtime->allocBlob(newCapacity);
+}
+
+void LazyAllocator::commitActivationStorage(const Blob &storage) {
+    IT_ASSERT(storage != nullptr, "Cannot commit null activation storage");
+    if (hasMemPool) {
+        IT_ASSERT(storage == memPoolPtr,
+                  "Fixed memory pool storage cannot be replaced");
+    } else {
+        ptr = storage;
     }
 }
 
+bool LazyAllocator::isCurrentActivationStorage(const Blob &storage) const {
+    return storage && storage == (hasMemPool ? memPoolPtr : ptr);
+}
+
 Blob LazyAllocator::getActivationBlob(size_t offset, size_t bytes) {
-    getPtr();
+    auto storage = prepareActivationStorage();
+    commitActivationStorage(storage);
+    return getActivationBlob(storage, offset, bytes);
+}
+
+Blob LazyAllocator::getActivationBlob(const Blob &storage, size_t offset,
+                                      size_t bytes) const {
+    IT_ASSERT(storage != nullptr, "Activation storage is not allocated");
     if (!hasMemPool) {
-        return make_ref<BlobObj>(ptr, offset, bytes);
+        return make_ref<BlobObj>(storage, offset, bytes);
     }
     IT_ASSERT(weightPeak <= memPoolSize);
     IT_ASSERT(offset <= memPoolSize - weightPeak);
     return make_ref<BlobObj>(
-        memPoolPtr, checkedAdd(weightPeak, offset, "Memory offset overflow"),
+        storage, checkedAdd(weightPeak, offset, "Memory offset overflow"),
         bytes);
 }
 
@@ -238,7 +308,9 @@ void *LazyAllocator::getHeapPtr() {
 
 Blob LazyAllocator::getHeapBlob(size_t offset, size_t bytes) {
     getHeapPtr();
-    return make_ref<BlobObj>(memPoolPtr, offset, bytes);
+    auto blob = make_ref<BlobObj>(memPoolPtr, offset, bytes);
+    heapBlobs.emplace_back(blob);
+    return blob;
 }
 
 size_t LazyAllocator::getAlignedSize(size_t size) {

--- a/src/ffi/ffi_infinitensor.cc
+++ b/src/ffi/ffi_infinitensor.cc
@@ -617,6 +617,7 @@ void init_graph_builder(py::module &m) {
         .def("data_malloc", &Handler::data_malloc,
              py::arg("useNaiveAllocator") = false, py::arg("memPoolSize") = 0,
              policy::automatic)
+        .def("trim_memory", &Handler::trim_memory, policy::automatic)
         .def("clone_KV", &Handler::clone_KV, policy::move)
         .def("free_heap", &Handler::free_heap, policy::move)
         .def("get_perf_time", &Handler::get_perf_time, policy::automatic)

--- a/test/core/test_graph.cc
+++ b/test/core/test_graph.cc
@@ -183,6 +183,256 @@ TEST(Graph, lazy_allocator_preserves_preloaded_user_data) {
     EXPECT_TRUE(matmul->getOutput()->equalData(vector<float>{3, 4}));
 }
 
+TEST(Graph, lazy_allocator_reuses_high_watermark_capacity) {
+    auto runtime = make_ref<TrackingCpuRuntimeObj>();
+    {
+        Graph g = make_ref<GraphObj>(runtime);
+        Tensor input = g->addTensor({8, 2}, DataType::Float32);
+        Tensor weight = g->addTensor({2, 2}, DataType::Float32);
+        input->setInput();
+        weight->setWeight();
+        auto matmul = g->addOp<MatmulObj>(input, weight, nullptr);
+        Tensor output = matmul->getOutput();
+        output->setOutput();
+
+        g->dataMalloc();
+        weight->copyin(vector<float>{1, 0, 0, 1});
+        const auto allocationCount = runtime->getAllocationCount();
+        const auto deallocationCount = runtime->getDeallocationCount();
+        const auto inputAddress = input->getRawDataPtr<const void *>();
+        const auto initialGeneration = g->getAllocationGeneration();
+
+        g->dataMalloc();
+        EXPECT_EQ(runtime->getAllocationCount(), allocationCount);
+        EXPECT_EQ(runtime->getDeallocationCount(), deallocationCount);
+        EXPECT_EQ(g->getAllocationGeneration(), initialGeneration);
+
+        for (int i = 0; i < 10000; ++i) {
+            const int batch = i % 2 == 0 ? 6 : 8;
+            input->setShape({batch, 2});
+            g->shape_infer();
+            g->dataMalloc();
+        }
+
+        EXPECT_EQ(runtime->getAllocationCount(), allocationCount);
+        EXPECT_EQ(runtime->getDeallocationCount(), deallocationCount);
+        EXPECT_EQ(input->getRawDataPtr<const void *>(), inputAddress);
+
+        vector<float> data(16);
+        for (size_t i = 0; i < data.size(); ++i)
+            data[i] = static_cast<float>(i);
+        input->copyin(data);
+        runtime->run(g);
+        EXPECT_TRUE(output->equalData(data));
+    }
+    EXPECT_EQ(runtime->getLiveAllocationCount(), 0);
+    EXPECT_EQ(runtime->getAllocationCount(), runtime->getDeallocationCount());
+}
+
+TEST(Graph, lazy_allocator_grows_and_trims_capacity) {
+    auto runtime = make_ref<TrackingCpuRuntimeObj>();
+    {
+        Graph g = make_ref<GraphObj>(runtime);
+        Tensor input = g->addTensor({8, 2}, DataType::Float32);
+        Tensor weight = g->addTensor({2, 2}, DataType::Float32);
+        input->setInput();
+        weight->setWeight();
+        auto matmul = g->addOp<MatmulObj>(input, weight, nullptr);
+        Tensor output = matmul->getOutput();
+        output->setOutput();
+
+        g->dataMalloc();
+        weight->copyin(vector<float>{1, 0, 0, 1});
+        ASSERT_GE(runtime->getAllocationSizes().size(), 2);
+        const auto initialCapacity = runtime->getAllocationSizes().back();
+        const auto allocationCount = runtime->getAllocationCount();
+        const auto deallocationCount = runtime->getDeallocationCount();
+
+        input->setShape({9, 2});
+        g->shape_infer();
+        g->dataMalloc();
+        ASSERT_EQ(runtime->getAllocationCount(), allocationCount + 1);
+        EXPECT_EQ(runtime->getDeallocationCount(), deallocationCount + 1);
+        EXPECT_EQ(runtime->getAllocationSizes().back(),
+                  initialCapacity + initialCapacity / 2);
+
+        const auto grownAllocationCount = runtime->getAllocationCount();
+        const auto grownDeallocationCount = runtime->getDeallocationCount();
+        input->setShape({4, 2});
+        g->shape_infer();
+        g->dataMalloc();
+        EXPECT_EQ(runtime->getAllocationCount(), grownAllocationCount);
+        EXPECT_EQ(runtime->getDeallocationCount(), grownDeallocationCount);
+
+        vector<float> data{1, 2, 3, 4, 5, 6, 7, 8};
+        input->copyin(data);
+        const auto generationBeforeTrim = g->getAllocationGeneration();
+        g->trimMemory();
+        EXPECT_EQ(runtime->getAllocationCount(), grownAllocationCount + 1);
+        EXPECT_EQ(runtime->getDeallocationCount(), grownDeallocationCount + 1);
+        EXPECT_EQ(runtime->getAllocationSizes().back(), 64);
+        EXPECT_GT(g->getAllocationGeneration(), generationBeforeTrim);
+
+        runtime->run(g);
+        EXPECT_TRUE(output->equalData(data));
+
+        const auto generationAfterTrim = g->getAllocationGeneration();
+        g->trimMemory();
+        EXPECT_EQ(runtime->getAllocationCount(), grownAllocationCount + 1);
+        EXPECT_EQ(runtime->getDeallocationCount(), grownDeallocationCount + 1);
+        EXPECT_EQ(g->getAllocationGeneration(), generationAfterTrim);
+    }
+    EXPECT_EQ(runtime->getLiveAllocationCount(), 0);
+    EXPECT_EQ(runtime->getAllocationCount(), runtime->getDeallocationCount());
+}
+
+TEST(Graph, lazy_allocator_trim_failure_preserves_committed_layout) {
+    auto runtime = make_ref<TrackingCpuRuntimeObj>();
+    {
+        Graph g = make_ref<GraphObj>(runtime);
+        Tensor input = g->addTensor({8, 2}, DataType::Float32);
+        Tensor weight = g->addTensor({2, 2}, DataType::Float32);
+        input->setInput();
+        weight->setWeight();
+        auto matmul = g->addOp<MatmulObj>(input, weight, nullptr);
+        Tensor output = matmul->getOutput();
+        output->setOutput();
+
+        g->dataMalloc();
+        weight->copyin(vector<float>{1, 0, 0, 1});
+        input->setShape({4, 2});
+        g->shape_infer();
+        g->dataMalloc();
+        const vector<float> data{1, 2, 3, 4, 5, 6, 7, 8};
+        input->copyin(data);
+
+        const auto inputAddress = input->getRawDataPtr<const void *>();
+        const auto outputAddress = output->getRawDataPtr<const void *>();
+        const auto generation = g->getAllocationGeneration();
+        const auto liveAllocations = runtime->getLiveAllocationCount();
+
+        runtime->failNextAlloc();
+        EXPECT_THROW(g->trimMemory(), std::bad_alloc);
+        EXPECT_EQ(input->getRawDataPtr<const void *>(), inputAddress);
+        EXPECT_EQ(output->getRawDataPtr<const void *>(), outputAddress);
+        EXPECT_EQ(g->getAllocationGeneration(), generation);
+        EXPECT_EQ(runtime->getLiveAllocationCount(), liveAllocations);
+
+        runtime->failNextBlobCopy();
+        EXPECT_THROW(g->trimMemory(), Exception);
+        EXPECT_EQ(input->getRawDataPtr<const void *>(), inputAddress);
+        EXPECT_EQ(output->getRawDataPtr<const void *>(), outputAddress);
+        EXPECT_EQ(g->getAllocationGeneration(), generation);
+        EXPECT_EQ(runtime->getLiveAllocationCount(), liveAllocations);
+
+        runtime->run(g);
+        EXPECT_TRUE(output->equalData(data));
+        EXPECT_NO_THROW(g->trimMemory());
+        runtime->run(g);
+        EXPECT_TRUE(output->equalData(data));
+    }
+    EXPECT_EQ(runtime->getLiveAllocationCount(), 0);
+    EXPECT_EQ(runtime->getAllocationCount(), runtime->getDeallocationCount());
+}
+
+TEST(Graph, graph_locks_allocator_mode) {
+    auto runtime = make_ref<TrackingCpuRuntimeObj>();
+
+    Graph dynamic = make_ref<GraphObj>(runtime);
+    dynamic->addTensor({4}, DataType::Float32)->setInput();
+    dynamic->dataMalloc();
+    EXPECT_THROW(dynamic->dataMalloc(true), Exception);
+    EXPECT_THROW(dynamic->dataMalloc(false, 1024), Exception);
+
+    Graph naive = make_ref<GraphObj>(runtime);
+    naive->addTensor({4}, DataType::Float32)->setInput();
+    naive->dataMalloc(true);
+    EXPECT_THROW(naive->dataMalloc(), Exception);
+
+    Graph fixed = make_ref<GraphObj>(runtime);
+    fixed->addTensor({4}, DataType::Float32)->setInput();
+    fixed->dataMalloc(false, 1024);
+    EXPECT_NO_THROW(fixed->dataMalloc());
+    EXPECT_THROW(fixed->dataMalloc(false, 2048), Exception);
+    EXPECT_THROW(fixed->trimMemory(), Exception);
+}
+
+TEST(Graph, allocation_failure_does_not_lock_allocator_mode) {
+    auto runtime = make_ref<TrackingCpuRuntimeObj>();
+
+    Graph fixed = make_ref<GraphObj>(runtime);
+    Tensor fixedInput = fixed->addTensor({4}, DataType::Float32);
+    fixedInput->setInput();
+    EXPECT_THROW(fixed->dataMalloc(false, 8), Exception);
+    EXPECT_FALSE(fixedInput->hasData());
+    EXPECT_NO_THROW(fixed->dataMalloc(false, 1024));
+    EXPECT_TRUE(fixedInput->hasData());
+
+    Graph allocationFailure = make_ref<GraphObj>(runtime);
+    Tensor dynamicInput = allocationFailure->addTensor({4}, DataType::Float32);
+    dynamicInput->setInput();
+    runtime->failNextAlloc();
+    EXPECT_THROW(allocationFailure->dataMalloc(false, 1024), std::bad_alloc);
+    EXPECT_FALSE(dynamicInput->hasData());
+    EXPECT_NO_THROW(allocationFailure->dataMalloc());
+    EXPECT_TRUE(dynamicInput->hasData());
+}
+
+TEST(Graph, allocation_generation_tracks_blob_extent_changes) {
+    auto runtime = make_ref<TrackingCpuRuntimeObj>();
+    Graph g = make_ref<GraphObj>(runtime);
+    Tensor input = g->addTensor({1}, DataType::Float32);
+    input->setInput();
+
+    g->dataMalloc();
+    const auto address = input->getRawDataPtr<const void *>();
+    const auto generation = g->getAllocationGeneration();
+    const auto allocationCount = runtime->getAllocationCount();
+
+    input->setShape({2});
+    g->dataMalloc();
+
+    EXPECT_EQ(input->getRawDataPtr<const void *>(), address);
+    EXPECT_EQ(runtime->getAllocationCount(), allocationCount);
+    EXPECT_EQ(input->getDataBlob()->getBytes(), input->getBytes());
+    EXPECT_GT(g->getAllocationGeneration(), generation);
+}
+
+TEST(Graph, fixed_pool_checks_capacity_and_heap_lifetime) {
+    auto runtime = make_ref<TrackingCpuRuntimeObj>();
+    {
+        Graph tooSmall = make_ref<GraphObj>(runtime);
+        tooSmall->addTensor({4}, DataType::Float32)->setInput();
+        EXPECT_THROW(tooSmall->dataMalloc(false, 8), Exception);
+    }
+
+    {
+        Graph g = make_ref<GraphObj>(runtime);
+        Tensor input = g->addTensor({4}, DataType::Float32);
+        input->setInput();
+        g->dataMalloc(false, 1024);
+        input->copyin(vector<float>{1, 2, 3, 4});
+
+        const auto generation = g->getAllocationGeneration();
+        Tensor oversized =
+            make_ref<TensorObj>(Shape{300}, DataType::Float32, runtime);
+        oversized->dataMalloc();
+        EXPECT_THROW(g->cloneKV(oversized), Exception);
+        EXPECT_EQ(g->getAllocationGeneration(), generation);
+
+        runtime->failNextBlobCopy();
+        EXPECT_THROW(g->cloneKV(input), Exception);
+        EXPECT_EQ(g->getAllocationGeneration(), generation);
+
+        auto clone = g->cloneKV(input);
+        EXPECT_THROW(g->freeHeap(), Exception);
+        clone.reset();
+        EXPECT_NO_THROW(g->freeHeap());
+    }
+    EXPECT_EQ(runtime->getLiveAllocationCount(), 0);
+    EXPECT_EQ(runtime->getAllocationCount(), runtime->getDeallocationCount());
+}
+
 TEST(Graph, owned_blobs_release_exactly_once) {
     auto runtime = make_ref<TrackingCpuRuntimeObj>();
     Tensor tensor =
@@ -305,7 +555,8 @@ TEST(Graph, lazy_allocation_failure_leaves_activations_without_data) {
         EXPECT_FALSE(input->hasData());
         EXPECT_FALSE(output->hasData());
         EXPECT_TRUE(weight->hasData());
-        EXPECT_EQ(runtime->getLiveAllocationCount(), 1);
+        // The old high-watermark pool remains available for a retry.
+        EXPECT_EQ(runtime->getLiveAllocationCount(), 2);
         EXPECT_THROW(runtime->run(g), Exception);
 
         g->dataMalloc();
@@ -367,7 +618,7 @@ TEST(Graph, lazy_weight_copy_failure_can_retry) {
         ASSERT_EQ(runtime->getAllocationSizes().size(), 1);
         EXPECT_EQ(runtime->getAllocationSizes()[0], weight->getBytes());
         EXPECT_TRUE(weight->equalData(vector<float>{1, 0, 0, 1}));
-        EXPECT_EQ(runtime->getLiveAllocationCount(), 2);
+        EXPECT_EQ(runtime->getLiveAllocationCount(), 1);
 
         g->dataMalloc();
         ASSERT_GE(runtime->getAllocationSizes().size(), 3);

--- a/test/cuda/test_cudagraph.cc
+++ b/test/cuda/test_cudagraph.cc
@@ -84,9 +84,13 @@ TEST(TestCudaRuntime, CudaGraph) {
     printf("with cudaGraph, latency: %f ms\n", milliseconds_2);
     EXPECT_GE(milliseconds_1, milliseconds_2);
 
-    // Reallocating graph memory invalidates the addresses captured above.
+    // Replanning an unchanged layout reuses the captured addresses.
+    const auto generationBeforeReplan = gCuda->getAllocationGeneration();
+    const auto addressBeforeReplan = input_q_d->getRawDataPtr<const void *>();
     gCuda->dataMalloc();
-    EXPECT_THROW(cudaRuntime->runWithCudaGraph(gCuda), Exception);
+    EXPECT_EQ(gCuda->getAllocationGeneration(), generationBeforeReplan);
+    EXPECT_EQ(input_q_d->getRawDataPtr<const void *>(), addressBeforeReplan);
+    EXPECT_NO_THROW(cudaRuntime->runWithCudaGraph(gCuda));
 }
 
 } // namespace infini


### PR DESCRIPTION
## 修改说明

本 PR 基于 #310 的内存所有权改造，继续处理动态 shape 下的内存池复用问题。

此前每次 shape 变化后，LazyAllocator 都会重新规划内存并重新创建 activation pool。即使新的内存需求没有超过已有容量，也会触发 Runtime 的内存分配和释放。

修改后的流程如下：

```text
shape 变化
    ↓
重新计算 Tensor offset 和 peak
    ↓
所需空间未超过当前容量
    ├── 复用已有 pool
    └── 超过容量时扩容并迁移需要保留的数据
```

---

## 1. 分离内存规划和物理内存释放

主要文件：

```text
include/core/lazy_allocator.h
src/core/lazy_allocator.cc
```

`LazyAllocator::init()` 现在只重置本次规划使用的状态：

```cpp
void LazyAllocator::init() {
    used = 0;
    peak = 0;
    freeBlocks.clear();
    headAddrToBlockSize.clear();
    tailAddrToBlockSize.clear();
}
```

已分配的 activation pool、weight pool 和 fixed pool 不会被释放。这样每次 `dataMalloc()` 仍会根据当前 shape 重新计算 Tensor 的生命周期和 offset，但可以继续使用原来的物理内存。

新增 `reset()` 用于彻底清理 allocator：

```cpp
void LazyAllocator::reset() {
    init();
    weightPeak = 0;
    heapPeak = 0;
    hasMemPool = false;
    memPoolSize = 0;
    ptr.reset();
    weightPtr.reset();
    memPoolPtr.reset();
    heapBlobs.clear();
}
```

两者的用途不同：

- `init()` 用于正常的动态 shape 重规划，保留物理内存；
- `reset()` 用于首次分配失败后的回滚，释放尚未提交的内存。

---

## 2. 复用并按需扩展 activation pool

主要文件：

```text
src/core/lazy_allocator.cc
src/core/graph.cc
```

重新规划后，如果所需 peak 没有超过当前 pool 容量，直接复用原来的 Storage：

```cpp
if (!forceNewStorage && ptr &&
    ((!exactCapacity && peak <= currentCapacity) ||
     (exactCapacity && peak == currentCapacity)))
    return ptr;
```

这里保留的是 Graph 使用过的最大容量，也就是高水位容量。例如 pool 已扩展到 64 MB，后续 shape 只需要 40 MB 或 56 MB 时，不再调用 Runtime 重新分配。

超过当前容量时，按照以下规则扩容：

```text
new capacity = max(required peak, current capacity × 1.5)
```

对应代码为：

```cpp
const auto grownCapacity =
    checkedAdd(currentCapacity, currentCapacity / 2,
               "Activation pool capacity overflow");

newCapacity = std::max(peak, grownCapacity);
```

保留一定的增长余量，可以减少 batch 连续增大时的重复分配。缩小后的闲置容量仍归当前 Graph 管理，可以继续供后续 Tensor 使用。

---

## 3. 扩容失败时保留原有内存布局

主要文件：

```text
src/core/graph.cc
src/core/lazy_allocator.cc
```

扩容时先申请新的 Storage，并基于它创建 Blob view。输入数据迁移成功后，再统一替换当前 pool 和 Tensor Blob：

```cpp
allocator.commitActivationStorage(activationStorage);

for (const auto &[tensor, blob] : activationBlobs)
    tensor->setDataBlob(blob);
```

如果内存申请或数据复制失败：

- 原 activation pool 不变；
- 原 Tensor 地址不变；
- `allocationGeneration` 不变；
- 新申请的 Storage 自动释放；
- 调用方可以再次执行 `dataMalloc()`。

当输入在同一个 pool 内移动可能发生覆盖时，会改用独立 Storage 完成迁移，避免一个输入覆盖另一个尚未复制的输入。

---

## 4. 首次分配失败后允许重新选择 allocator

主要文件：

```text
include/core/graph.h
src/core/graph.cc
```

此前 allocator 模式在实际分配完成前就会被锁定。第一次使用的 fixed pool 容量不足时，Graph 仍会保留该模式和容量，之后无法增大 fixed pool，也无法改用 Dynamic 或 Naive allocator。

现在首次分配会保存 Tensor 原有的 Blob：

```cpp
vector<Blob> previousData;
previousData.reserve(tensors.size());

for (const auto &tensor : tensors)
    previousData.emplace_back(tensor->getDataBlob());
```

分配失败时恢复这些 Blob，并清理本次分配产生的状态：

```cpp
for (size_t i = 0; i < tensors.size(); ++i)
    tensors[i]->setDataBlob(previousData[i]);

allocator.reset();
allocationMode = AllocationMode::Uninitialized;
fixedPoolSize = 0;
weightAllocated = false;
fixedPoolLayoutCommitted = false;
allocationGeneration = previousGeneration;
```

因此，下面两种重试方式都可以正常工作：

```cpp
graph->dataMalloc(false, 8);     // fixed pool 容量不足
graph->dataMalloc(false, 1024);  // 增大容量后重试
```

```cpp
graph->dataMalloc(false, 1024);  // Runtime 分配失败
graph->dataMalloc();             // 改用 Dynamic allocator
```

allocator 模式只在首次分配成功后固定。

---

## 5. 增加主动收缩接口

主要文件：

```text
include/core/graph.h
include/core/graph_handler.h
src/core/graph.cc
src/ffi/ffi_infinitensor.cc
pyinfinitensor/src/pyinfinitensor/onnx.py
```

默认情况下，Graph 会保留已经申请的高水位容量。确定后续不再使用较大 shape 时，可以主动收缩到当前实际需求：

```cpp
graph->trimMemory();
```

Python 接口为：

```python
stub.trim_memory()
```

如果当前容量已经等于规划结果，`trimMemory()` 不会重新分配，也不会更新 `allocationGeneration`。

该接口只适用于 Dynamic Pool。Naive allocator 和 Fixed Pool 不支持主动收缩。

---

## 6. 完善 Fixed Pool 和 Heap 的状态检查

主要文件：

```text
include/core/graph.h
include/core/lazy_allocator.h
src/core/graph.cc
src/core/lazy_allocator.cc
```

Graph 首次成功分配后，会固定使用以下模式之一：

```cpp
enum class AllocationMode {
    Uninitialized,
    Naive,
    DynamicPool,
    FixedPool,
};
```

同一个 Graph 后续不能切换 allocator 模式，Fixed Pool 的容量也不能修改。

Fixed Pool 的容量检查现在覆盖：

```text
weight peak + activation peak + heap peak
```

总需求超过容量时，在创建 Blob view 前直接返回错误。

通过 `cloneKV()` 创建的 heap Blob 会记录弱引用。仍有 Tensor 使用 heap 内存时，`freeHeap()` 会拒绝重置 heap offset，避免旧 Tensor 指向已经重新分配的区域。

`cloneKV()` 分配或复制失败时，也会恢复分配前的 heap peak。

---

## 7. 调整 allocationGeneration 的更新条件

主要文件：

```text
src/core/graph.cc
test/cuda/test_cudagraph.cc
```

此前 `allocationGeneration` 只比较 Tensor 地址。由于 allocator 会进行内存对齐，shape 变化后地址可能不变，但 Blob 的有效字节数已经变化。

现在记录的内存状态包括：

```text
Tensor 地址 + Blob 有效字节数
```

```cpp
using TensorMemoryState = std::pair<const void *, size_t>;

const auto getTensorMemoryState = [](const Tensor &tensor) {
    if (!tensor->hasData())
        return TensorMemoryState{nullptr, 0};

    return TensorMemoryState{
        tensor->getRawDataPtr<const void *>(),
        tensor->getDataBlob()->getBytes(),
    };
};
```

地址或有效范围发生变化时，`allocationGeneration` 才会递增。重复执行相同布局的 `dataMalloc()` 不会产生新的 generation。

CUDA Graph 的行为相应调整为：

- 重复规划但地址和布局不变时，允许继续 replay；
- 地址、有效范围或 shape 变化时，拒绝使用旧 capture。

自动重新 capture 不在本 PR 范围内，仍由后续改动处理。