### PR TITLE
Support dynamic CUDA Graph recapture and caching

### DIFF
--- a/include/core/blob.h
+++ b/include/core/blob.h
@@ -1,6 +1,7 @@
 #pragma once
 #include "core/common.h"
 #include "core/ref.h"
+#include <cstdint>
 
 namespace infini {
 
@@ -13,6 +14,8 @@ class BlobObj {
     void *ptr;
     size_t bytes;
     Ref<BlobObj> owner;
+    uint64_t storageId;
+    size_t storageOffset;
 
   public:
     BlobObj(Runtime runtime, void *ptr, size_t bytes);
@@ -22,6 +25,8 @@ class BlobObj {
     ~BlobObj() noexcept;
 
     size_t getBytes() const { return bytes; }
+    uint64_t getStorageId() const { return storageId; }
+    size_t getStorageOffset() const { return storageOffset; }
     template <typename T> T getPtr() const {
         IT_ASSERT(ptr != nullptr, "Blob has no backing memory");
         return reinterpret_cast<T>(ptr);

--- a/include/core/graph.h
+++ b/include/core/graph.h
@@ -7,17 +7,49 @@
 
 namespace infini {
 
+class GraphCaptureStateObj {
+  private:
+    uint64_t id;
+    Runtime runtime;
+    size_t generation = 0;
+    size_t topologyEpoch = 0;
+    size_t updateDepth = 0;
+    bool pendingLayoutChange = false;
+    bool pendingStorageChange = false;
+    bool pendingTopologyChange = false;
+
+    void applyPendingChanges() noexcept;
+
+  public:
+    GraphCaptureStateObj(uint64_t id, Runtime runtime)
+        : id(id), runtime(std::move(runtime)) {}
+
+    uint64_t getId() const { return id; }
+    size_t getGeneration() const { return generation; }
+    size_t getTopologyEpoch() const { return topologyEpoch; }
+
+    void beginUpdate();
+    void commitUpdate() noexcept;
+    void finishMemoryUpdate(bool layoutChanged, bool storageChanged);
+    void markChanged(bool storageChanged) noexcept;
+    void markTopologyChanged() noexcept;
+};
+
 class GraphObj : public Object {
   protected:
     Runtime runtime;
     TensorVec tensors;
     OpVec ops;
     LazyAllocator allocator;
+    Ref<GraphCaptureStateObj> captureState;
 
   public:
     explicit GraphObj(Runtime runtime)
-        : runtime(runtime), allocator(runtime), sorted(false){};
+        : runtime(runtime), allocator(runtime),
+          captureState(make_ref<GraphCaptureStateObj>(guid, runtime)),
+          sorted(false){};
     GraphObj(Runtime runtime, OpVec ops_in);
+    ~GraphObj() override;
     string toString() const override;
     Runtime getRuntime() const { return runtime; }
 
@@ -30,17 +62,9 @@ class GraphObj : public Object {
     Tensor cloneTensor(const Tensor &tensor) {
         return addTensor(tensor->clone(runtime));
     }
-    void removeOperator(Operator op) {
-        auto it = std::find(ops.begin(), ops.end(), op);
-        if (it != ops.end())
-            ops.erase(it);
-    }
+    void removeOperator(Operator op);
 
-    void removeTensor(Tensor tensor) {
-        auto it = std::find(tensors.begin(), tensors.end(), tensor);
-        if (it != tensors.end())
-            tensors.erase(it);
-    }
+    void removeTensor(Tensor tensor);
 
     void deleteConnection(Tensor tensor, Operator op);
     void addConnection(Tensor tensor, Operator op);
@@ -76,6 +100,11 @@ class GraphObj : public Object {
     void validateMemory() const;
 
     size_t getAllocationGeneration() const { return allocationGeneration; }
+    uint64_t getCaptureStateId() const { return captureState->getId(); }
+    size_t getCaptureGeneration() const {
+        return captureState->getGeneration();
+    }
+    size_t getTopologyEpoch() const { return captureState->getTopologyEpoch(); }
 
     Tensor cloneKV(Tensor &tensor);
 
@@ -139,6 +168,9 @@ class GraphObj : public Object {
                             bool trim);
 
     void lockAllocationMode(bool useNaiveAllocator, size_t memPoolSize);
+
+    void registerTensorCaptureState(const Tensor &tensor);
+    void markTopologyChanged();
 
     /**
      * @brief Add reverse connections and Op relationship in ctor.

--- a/include/core/runtime.h
+++ b/include/core/runtime.h
@@ -86,6 +86,8 @@ class RuntimeObj : public std::enable_shared_from_this<RuntimeObj> {
 
     int getDeviceId() const { return deviceId; }
 
+    virtual void invalidateGraphCaptureCache(uint64_t) noexcept {}
+
     virtual void initComm(const string &name, int worldSize, int rank) = 0;
 
     virtual CommunicatorObj &getCommunicator() const = 0;

--- a/include/core/tensor.h
+++ b/include/core/tensor.h
@@ -125,6 +125,7 @@ class TensorObj : public TensorBaseObj {
 
     Tensor clone() const {
         auto obj = make_ref<TensorObj>(*this);
+        obj->clearCaptureStates();
         obj->freeData();
         obj->targets.clear();
         obj->source.reset();
@@ -132,6 +133,7 @@ class TensorObj : public TensorBaseObj {
     }
     Tensor clone(Runtime runtime) const {
         auto obj = make_ref<TensorObj>(*this);
+        obj->clearCaptureStates();
         obj->runtime = runtime;
         obj->freeData();
         obj->targets.clear();

--- a/include/core/tensor_base.h
+++ b/include/core/tensor_base.h
@@ -5,6 +5,7 @@
 #include "core/runtime.h"
 namespace infini {
 class GraphObj;
+class GraphCaptureStateObj;
 class TensorBaseObj : public Object {
     friend class GraphObj;
 
@@ -24,18 +25,16 @@ class TensorBaseObj : public Object {
     WRef<OperatorObj> source;
     Blob data;
     Runtime runtime;
+    vector<WRef<GraphCaptureStateObj>> captureStates;
 
   public:
     TensorBaseObj(int dim, DataType dtype, Runtime runtime);
     virtual ~TensorBaseObj() {}
 
-    void dataMalloc(const Blob &blob) {
-        IT_ASSERT(data == nullptr);
-        data = blob;
-    }
+    void dataMalloc(const Blob &blob);
     Blob getDataBlob() const { return data; }
     bool hasData() const { return data != nullptr; }
-    void freeData() { data = nullptr; }
+    void freeData();
     template <typename T> T getRawDataPtr() const {
         static_assert(std::is_pointer_v<T>,
                       "Raw data pointer has a type of pointer");
@@ -54,7 +53,14 @@ class TensorBaseObj : public Object {
     OpVec getTargets() const { return wrefs_to_refs(targets); }
     Operator getSource() const { return source.lock(); }
 
+  protected:
+    void clearCaptureStates() { captureStates.clear(); }
+    void notifyCaptureState(bool storageChanged);
+
   private:
+    void registerCaptureState(const Ref<GraphCaptureStateObj> &state);
+    void unregisterCaptureState(uint64_t stateId);
+
     void addTarget(const Operator &op) { targets.emplace_back(op); }
     void setSource(const Operator &op) { source = op; }
     void removeTarget(const Operator &op) {

--- a/include/cuda/cuda_common.h
+++ b/include/cuda/cuda_common.h
@@ -114,18 +114,28 @@ using CudaPtr = void *;
 
 class CUDAStream {
   public:
+    class Guard {
+      private:
+        cudaStream_t previous;
+
+      public:
+        explicit Guard(cudaStream_t stream) : previous(_stream) {
+            _stream = stream;
+        }
+        Guard(const Guard &) = delete;
+        Guard &operator=(const Guard &) = delete;
+        ~Guard() { _stream = previous; }
+    };
+
     CUDAStream(const CUDAStream &) = delete;
     CUDAStream(CUDAStream &&) = delete;
     void operator=(const CUDAStream &) = delete;
     void operator=(CUDAStream &&) = delete;
     static cudaStream_t getCurrentStream() { return _stream; }
-    static void Init() { CUDAStream::_stream = 0; };
-    static void createStream() { checkCudaError(cudaStreamCreate(&_stream)); }
-    static void destroyStream() { checkCudaError(cudaStreamDestroy(_stream)); }
 
   private:
     CUDAStream(){};
-    static cudaStream_t _stream;
+    static thread_local cudaStream_t _stream;
 };
 
 } // namespace infini

--- a/include/cuda/cuda_runtime.h
+++ b/include/cuda/cuda_runtime.h
@@ -1,6 +1,9 @@
 #pragma once
 #include "core/runtime.h"
 #include "cuda/cuda_common.h"
+#include <list>
+#include <mutex>
+#include <unordered_map>
 #ifdef INFINI_USE_NCCL
 #include "cuda/nccl_communicator.h"
 #endif
@@ -9,62 +12,73 @@ namespace infini {
 
 class CudaRuntimeObj : public RuntimeObj {
   private:
-    cudnnHandle_t cudnn;
-    cublasHandle_t cublas;
+    struct CapturedTensorState {
+        const TensorObj *tensor;
+        int dtype;
+        vector<int> shape;
+        size_t tensorBytes;
+        uint64_t storageId;
+        size_t storageOffset;
+        size_t blobBytes;
+        const void *address;
+
+        bool operator==(const CapturedTensorState &other) const;
+    };
+
+    struct CapturedGraphState {
+        uint64_t graphId;
+        size_t topologyEpoch;
+        vector<CapturedTensorState> tensors;
+
+        bool operator==(const CapturedGraphState &other) const;
+    };
+
+    struct CudaGraphCacheEntry {
+        WRef<GraphObj> owner;
+        CapturedGraphState state;
+        cudaGraph_t graph = nullptr;
+        cudaGraphExec_t instance = nullptr;
+
+        CudaGraphCacheEntry(WRef<GraphObj> owner, CapturedGraphState state)
+            : owner(std::move(owner)), state(std::move(state)) {}
+        ~CudaGraphCacheEntry() noexcept;
+        CudaGraphCacheEntry(const CudaGraphCacheEntry &) = delete;
+        CudaGraphCacheEntry &operator=(const CudaGraphCacheEntry &) = delete;
+    };
+
+    using CudaGraphCache = std::list<std::unique_ptr<CudaGraphCacheEntry>>;
+
+    struct ActiveCudaGraphState {
+        CudaGraphCache::iterator entry;
+        size_t generation;
+    };
+
+    cudnnHandle_t cudnn = nullptr;
+    cublasHandle_t cublas = nullptr;
     std::unique_ptr<CommunicatorObj> comm;
-    CudaPtr workspace;
-    size_t workspaceSize;
-    bool isCudaGraphCreated;
-    cudaGraph_t cudaGraph;
-    cudaGraphExec_t cudaGraphInstance;
-    WRef<GraphObj> cudaGraphOwner;
-    size_t cudaGraphAllocationGeneration = 0;
-    vector<const TensorObj *> cudaGraphTensors;
-    vector<const void *> cudaGraphTensorAddresses;
-    vector<vector<int>> cudaGraphTensorShapes;
+    CudaPtr workspace = nullptr;
+    size_t workspaceSize = 7ll << 30;
+    mutable cudaStream_t stream = nullptr;
+    size_t cudaGraphCacheCapacity;
+    size_t cudaGraphCaptureCount = 0;
+    CudaGraphCache cudaGraphCache;
+    std::unordered_map<uint64_t, ActiveCudaGraphState> activeCudaGraphs;
+    mutable std::recursive_mutex executionMutex;
+    mutable std::recursive_mutex cacheMutex;
 
   public:
-    explicit CudaRuntimeObj(int deviceId = 0)
-        : RuntimeObj(Device::CUDA, deviceId) {
-
-        checkCudaError(cudaSetDevice(deviceId));
-        checkCudnnError(cudnnCreate(&cudnn));
-        checkCublasError(cublasCreate(&cublas));
-        // 10GB for Longformer
-        // size_t longformerNum = 3lu * (1 << 30);
-        workspaceSize = 7ll << 30; // 7 GB
-        workspace = alloc(workspaceSize);
-        isCudaGraphCreated = false;
-        CUDAStream::Init();
-    }
-    virtual ~CudaRuntimeObj() {
-        try {
-            if (isCudaGraphCreated) {
-                checkCudaError(cudaGraphExecDestroy(cudaGraphInstance));
-                checkCudaError(cudaGraphDestroy(cudaGraph));
-                CUDAStream::destroyStream();
-            }
-            dealloc(workspace);
-            checkCudnnError(cudnnDestroy(cudnn));
-            checkCublasError(cublasDestroy(cublas));
-        } catch (const std::exception &e) {
-            std::cerr << "Error in ~CudaRuntimeObj: " << e.what() << std::endl;
-        }
-    }
+    explicit CudaRuntimeObj(int deviceId = 0,
+                            size_t cudaGraphCacheCapacity = 16);
+    ~CudaRuntimeObj() override;
     string toString() const override;
 
     void run(const Graph &graph, bool tune = false,
-             bool profiling = false) const;
+             bool profiling = false) const override;
     // double runEvaluation(const Graph &graph, int nWarmups,
     //                      int nEvaluations) const;
     void sync() const;
-    CudaPtr alloc(size_t size) override {
-        void *ptr;
-        checkCudaError(cudaMalloc(&ptr, size));
-        // printf("cuda malloc: %p %lu bytes\n", ptr, size);
-        return ptr;
-    }
-    void dealloc(void *ptr) override { checkCudaError(cudaFree(ptr)); }
+    CudaPtr alloc(size_t size) override;
+    void dealloc(void *ptr) override;
     cudnnHandle_t cudnnHandle() const { return cudnn; }
     cublasHandle_t cublasHandle() const { return cublas; }
     size_t getWorkspaceSize() const { return workspaceSize; }
@@ -74,23 +88,21 @@ class CudaRuntimeObj : public RuntimeObj {
     }
 
     void copyBlobFromCPU(void *dst, const void *src,
-                         size_t bytes) const override {
-        checkCudaError(cudaMemcpy(dst, src, bytes, cudaMemcpyHostToDevice));
-    }
+                         size_t bytes) const override;
 
-    void copyBlobToCPU(void *dst, const void *src,
-                       size_t bytes) const override {
-        checkCudaError(cudaMemcpy(dst, src, bytes, cudaMemcpyDeviceToHost));
-    }
+    void copyBlobToCPU(void *dst, const void *src, size_t bytes) const override;
 
     void copyBlobInsideRuntime(void *dst, const void *src,
-                               size_t bytes) const override {
-        checkCudaError(cudaMemcpy(dst, src, bytes, cudaMemcpyDeviceToDevice));
-    }
+                               size_t bytes) const override;
 
     void runWithoutSync(const Graph &graph) const;
 
     void runWithCudaGraph(const Graph &graph);
+
+    void clearCudaGraphCache();
+    size_t getCudaGraphCacheSize() const;
+    size_t getCudaGraphCaptureCount() const;
+    void invalidateGraphCaptureCache(uint64_t graphId) noexcept override;
 
     // init communicator
     void initComm(const string &name, int worldSize, int rank) final;
@@ -99,5 +111,19 @@ class CudaRuntimeObj : public RuntimeObj {
 
   private:
     void tune(const Graph &graph, bool profiling) const;
+    void activateDevice() const;
+    void bindLibraryHandlesToStream() const;
+    void ensureExecutionStream() const;
+    void runWithoutSyncImpl(const Graph &graph, bool validate) const;
+    void syncImpl() const;
+    CapturedGraphState captureStateOf(const Graph &graph) const;
+    std::unique_ptr<CudaGraphCacheEntry> captureGraph(const Graph &graph,
+                                                      CapturedGraphState state);
+    void recoverExecutionStreamAfterFailure() noexcept;
+    void clearCudaGraphCacheImpl() noexcept;
+    void eraseGraphCacheEntries(uint64_t graphId) noexcept;
+    void purgeExpiredGraphCacheEntries() noexcept;
+    void markActiveGraph(CudaGraphCache::iterator entry, size_t generation);
+    void clearActiveGraph(const CudaGraphCacheEntry *entry) noexcept;
 };
 } // namespace infini

--- a/pyinfinitensor/tests/test_api.py
+++ b/pyinfinitensor/tests/test_api.py
@@ -5,6 +5,22 @@ import numpy as np
 
 
 class TestPythonAPI(unittest.TestCase):
+    @unittest.skipUnless(hasattr(backend, "CudaRuntime"), "CUDA is not enabled")
+    def test_cuda_graph_cache_api(self):
+        runtime = backend.CudaRuntime(device=0, cuda_graph_cache_capacity=2)
+        self.assertEqual(runtime.cuda_graph_cache_size(), 0)
+        self.assertEqual(runtime.cuda_graph_capture_count(), 0)
+        runtime.clear_cuda_graph_cache()
+        self.assertEqual(runtime.cuda_graph_cache_size(), 0)
+        self.assertEqual(runtime.cuda_graph_capture_count(), 0)
+
+        factory_runtime = backend.cuda_runtime(
+            device=0, cuda_graph_cache_capacity=2
+        )
+        self.assertEqual(factory_runtime.cuda_graph_cache_size(), 0)
+        with self.assertRaises(RuntimeError):
+            backend.CudaRuntime(device=0, cuda_graph_cache_capacity=0)
+
     def test_copyin_numpy(self):
         dims = [2, 3, 5, 4]
         np_array = np.random.random(dims).astype(np.float32)

--- a/src/core/blob.cc
+++ b/src/core/blob.cc
@@ -1,18 +1,27 @@
 #include "core/blob.h"
 #include "core/runtime.h"
+#include <atomic>
 #include <cstdio>
 
 namespace infini {
 
+namespace {
+std::atomic<uint64_t> nextStorageId{1};
+}
+
 BlobObj::BlobObj(Runtime runtime, void *ptr, size_t bytes)
-    : runtime(std::move(runtime)), ptr(ptr), bytes(bytes) {
+    : runtime(std::move(runtime)), ptr(ptr), bytes(bytes),
+      storageId(nextStorageId.fetch_add(1, std::memory_order_relaxed)),
+      storageOffset(0) {
     IT_ASSERT(this->runtime != nullptr, "Blob requires a runtime");
     IT_ASSERT(ptr != nullptr, "Blob requires non-null backing memory");
 }
 
 BlobObj::BlobObj(Ref<BlobObj> owner, size_t offset, size_t bytes)
     : runtime(owner ? owner->runtime : nullptr), ptr(nullptr), bytes(bytes),
-      owner(std::move(owner)) {
+      owner(std::move(owner)),
+      storageId(this->owner ? this->owner->storageId : 0),
+      storageOffset(this->owner ? this->owner->storageOffset + offset : 0) {
     IT_ASSERT(this->owner != nullptr, "Blob view requires an owner");
     IT_ASSERT(offset <= this->owner->bytes, "Blob view offset is out of range");
     IT_ASSERT(bytes <= this->owner->bytes - offset,

--- a/src/core/graph.cc
+++ b/src/core/graph.cc
@@ -6,8 +6,56 @@
 
 namespace infini {
 
+void GraphCaptureStateObj::applyPendingChanges() noexcept {
+    if (!pendingLayoutChange && !pendingStorageChange && !pendingTopologyChange)
+        return;
+    ++generation;
+    if (pendingTopologyChange)
+        ++topologyEpoch;
+    if (pendingStorageChange || pendingTopologyChange)
+        runtime->invalidateGraphCaptureCache(id);
+    pendingLayoutChange = false;
+    pendingStorageChange = false;
+    pendingTopologyChange = false;
+}
+
+void GraphCaptureStateObj::beginUpdate() { ++updateDepth; }
+
+void GraphCaptureStateObj::commitUpdate() noexcept {
+    if (updateDepth == 0)
+        return;
+    --updateDepth;
+    if (updateDepth == 0)
+        applyPendingChanges();
+}
+
+void GraphCaptureStateObj::finishMemoryUpdate(bool layoutChanged,
+                                              bool storageChanged) {
+    IT_ASSERT(updateDepth == 1, "Unexpected nested capture state update");
+    pendingLayoutChange = pendingTopologyChange || layoutChanged;
+    pendingStorageChange = pendingTopologyChange || storageChanged;
+    commitUpdate();
+}
+
+void GraphCaptureStateObj::markChanged(bool storageChanged) noexcept {
+    pendingLayoutChange = true;
+    pendingStorageChange = pendingStorageChange || storageChanged;
+    if (updateDepth == 0)
+        applyPendingChanges();
+}
+
+void GraphCaptureStateObj::markTopologyChanged() noexcept {
+    pendingLayoutChange = true;
+    pendingStorageChange = true;
+    pendingTopologyChange = true;
+    if (updateDepth == 0)
+        applyPendingChanges();
+}
+
 GraphObj::GraphObj(Runtime runtime, OpVec ops_in)
-    : runtime(runtime), allocator(runtime), sorted(false) {
+    : runtime(runtime), allocator(runtime),
+      captureState(make_ref<GraphCaptureStateObj>(guid, runtime)),
+      sorted(false) {
     map<UidBaseType, Tensor> tensorPool;
     // Clone tensors
     for (const auto &op : ops_in) {
@@ -42,8 +90,23 @@ GraphObj::GraphObj(Runtime runtime, OpVec ops_in)
     }
 }
 
-void GraphObj::addOperatorAndConnect(const Operator &op) {
+GraphObj::~GraphObj() {
+    captureState->markTopologyChanged();
+    for (const auto &tensor : tensors)
+        tensor->unregisterCaptureState(captureState->getId());
+}
+
+void GraphObj::registerTensorCaptureState(const Tensor &tensor) {
+    tensor->registerCaptureState(captureState);
+}
+
+void GraphObj::markTopologyChanged() {
     sorted = false;
+    captureState->markTopologyChanged();
+}
+
+void GraphObj::addOperatorAndConnect(const Operator &op) {
+    markTopologyChanged();
     ops.push_back(op);
     for (auto &input : op->getInputs()) {
         if (input) {
@@ -196,8 +259,57 @@ void GraphObj::trimMemory() {
 
 void GraphObj::dataMallocImpl(bool useNaiveAllocator, size_t memPoolSize,
                               bool trim) {
+    struct CaptureMemoryState {
+        uint64_t storageId;
+        size_t storageOffset;
+        size_t blobBytes;
+        const void *address;
+
+        bool operator==(const CaptureMemoryState &other) const {
+            return storageId == other.storageId &&
+                   storageOffset == other.storageOffset &&
+                   blobBytes == other.blobBytes && address == other.address;
+        }
+        bool operator!=(const CaptureMemoryState &other) const {
+            return !(*this == other);
+        }
+    };
+    const auto getCaptureMemoryState = [](const Tensor &tensor) {
+        const auto &blob = tensor->getDataBlob();
+        if (!blob)
+            return CaptureMemoryState{0, 0, 0, nullptr};
+        return CaptureMemoryState{blob->getStorageId(),
+                                  blob->getStorageOffset(), blob->getBytes(),
+                                  tensor->getRawDataPtr<const void *>()};
+    };
+    vector<CaptureMemoryState> previousCaptureStates;
+    previousCaptureStates.reserve(tensors.size());
+    for (const auto &tensor : tensors)
+        previousCaptureStates.emplace_back(getCaptureMemoryState(tensor));
+    const auto finishCaptureStateUpdate = [&]() {
+        bool layoutChanged = previousCaptureStates.size() != tensors.size();
+        bool storageChanged = layoutChanged;
+        for (size_t i = 0;
+             i < previousCaptureStates.size() && i < tensors.size(); ++i) {
+            const auto current = getCaptureMemoryState(tensors[i]);
+            layoutChanged =
+                layoutChanged || previousCaptureStates[i] != current;
+            storageChanged =
+                storageChanged ||
+                previousCaptureStates[i].storageId != current.storageId;
+        }
+        captureState->finishMemoryUpdate(layoutChanged, storageChanged);
+    };
+
+    captureState->beginUpdate();
     if (allocationMode != AllocationMode::Uninitialized) {
-        dataMallocImplCore(useNaiveAllocator, memPoolSize, trim);
+        try {
+            dataMallocImplCore(useNaiveAllocator, memPoolSize, trim);
+            finishCaptureStateUpdate();
+        } catch (...) {
+            finishCaptureStateUpdate();
+            throw;
+        }
         return;
     }
 
@@ -209,6 +321,7 @@ void GraphObj::dataMallocImpl(bool useNaiveAllocator, size_t memPoolSize,
     const auto previousGeneration = allocationGeneration;
     try {
         dataMallocImplCore(useNaiveAllocator, memPoolSize, trim);
+        finishCaptureStateUpdate();
     } catch (...) {
         for (size_t i = 0; i < tensors.size(); ++i)
             tensors[i]->setDataBlob(previousData[i]);
@@ -220,6 +333,7 @@ void GraphObj::dataMallocImpl(bool useNaiveAllocator, size_t memPoolSize,
         fixedPoolTensorLayout.clear();
         fixedPoolActivationLayout.clear();
         allocationGeneration = previousGeneration;
+        finishCaptureStateUpdate();
         throw;
     }
 }
@@ -477,6 +591,7 @@ Tensor GraphObj::cloneKV(Tensor &tensor) {
                 throw;
             }
             ++allocationGeneration;
+            captureState->markChanged(true);
         }
     } else {
         if (tensor->hasData()) {
@@ -510,10 +625,16 @@ void GraphObj::freeHeap() {
     allocator.freeHeap();
     if (changed)
         ++allocationGeneration;
+    if (changed)
+        captureState->markChanged(true);
 }
 
 Tensor GraphObj::addTensor(Shape dim, DataType dtype) {
-    return tensors.emplace_back(make_ref<TensorObj>(dim, dtype, runtime));
+    auto tensor = make_ref<TensorObj>(dim, dtype, runtime);
+    registerTensorCaptureState(tensor);
+    tensors.emplace_back(tensor);
+    markTopologyChanged();
+    return tensor;
 }
 
 Tensor GraphObj::addTensor(const Tensor &tensor) {
@@ -522,6 +643,8 @@ Tensor GraphObj::addTensor(const Tensor &tensor) {
                   tensor->getRuntime()->toString() + " to " +
                   runtime->toString());
     tensors.emplace_back(tensor);
+    registerTensorCaptureState(tensor);
+    markTopologyChanged();
     return tensor;
 }
 
@@ -529,6 +652,23 @@ TensorVec GraphObj::addTensor(const TensorVec &tensors) {
     for (auto &t : tensors)
         addTensor(t);
     return tensors;
+}
+
+void GraphObj::removeOperator(Operator op) {
+    auto it = std::find(ops.begin(), ops.end(), op);
+    if (it == ops.end())
+        return;
+    ops.erase(it);
+    markTopologyChanged();
+}
+
+void GraphObj::removeTensor(Tensor tensor) {
+    auto it = std::find(tensors.begin(), tensors.end(), tensor);
+    if (it == tensors.end())
+        return;
+    tensor->unregisterCaptureState(captureState->getId());
+    tensors.erase(it);
+    markTopologyChanged();
 }
 
 OpVec GraphObj::getComputeOps() const {
@@ -549,6 +689,7 @@ void GraphObj::deleteConnection(Tensor tensor, Operator op) {
         tensor->getSource()->removeSuccessors(op);
         op->removePredecessors(tensor->getSource());
     }
+    markTopologyChanged();
 }
 
 // add op as a target
@@ -558,6 +699,7 @@ void GraphObj::addConnection(Tensor tensor, Operator op) {
         tensor->getSource()->addSuccessors(op);
         op->addPredecessors(tensor->getSource());
     }
+    markTopologyChanged();
 }
 
 void GraphObj::replaceConnection(Tensor oldTensor, Tensor newTensor,

--- a/src/core/tensor.cc
+++ b/src/core/tensor.cc
@@ -1,5 +1,6 @@
 #include "core/tensor.h"
 #include "core/blob.h"
+#include "core/graph.h"
 #include "core/operator.h"
 #include "core/runtime.h"
 #include "utils/dataloader.h"
@@ -82,8 +83,11 @@ Shape TensorObj::getStride() const {
 
 void TensorObj::setShape(Shape shape_) {
     const auto size = getTensorSize(shape_, dtype);
+    if (shape == shape_)
+        return;
     shape = std::move(shape_);
     _size = size;
+    notifyCaptureState(false);
 }
 
 void TensorObj::dumpData(std::ofstream &ofs) const {
@@ -182,8 +186,16 @@ bool TensorObj::equalData(const Tensor &rhs, double relativeError) const {
 
 void TensorObj::dataMalloc() {
     if (!data || data->getBytes() != getBytes()) {
+        const bool releasedStorage = data != nullptr;
         data.reset();
-        data = runtime->allocBlob(getBytes());
+        try {
+            data = runtime->allocBlob(getBytes());
+        } catch (...) {
+            if (releasedStorage)
+                notifyCaptureState(true);
+            throw;
+        }
+        notifyCaptureState(true);
     }
 }
 
@@ -209,7 +221,19 @@ void TensorObj::setData(
     }
 }
 
-void TensorObj::setDataBlob(const Blob &blob) { this->data = blob; }
+void TensorObj::setDataBlob(const Blob &blob) {
+    const auto previousStorageId = data ? data->getStorageId() : 0;
+    const auto previousAddress = data ? data->getPtr<const void *>() : nullptr;
+    const auto previousBytes = data ? data->getBytes() : 0;
+    const auto nextStorageId = blob ? blob->getStorageId() : 0;
+    const auto nextAddress = blob ? blob->getPtr<const void *>() : nullptr;
+    const auto nextBytes = blob ? blob->getBytes() : 0;
+    if (previousStorageId == nextStorageId && previousAddress == nextAddress &&
+        previousBytes == nextBytes)
+        return;
+    data = blob;
+    notifyCaptureState(previousStorageId != nextStorageId);
+}
 
 void TensorObj::load(std::string file_path) { loadTensorData(this, file_path); }
 

--- a/src/core/tensor_base.cc
+++ b/src/core/tensor_base.cc
@@ -1,9 +1,60 @@
 #include "core/tensor_base.h"
 #include "core/blob.h"
+#include "core/graph.h"
 #include "core/runtime.h"
+#include <algorithm>
 namespace infini {
 
 TensorBaseObj::TensorBaseObj(int dim, DataType dtype, Runtime runtime)
     : dim(dim), dtype(dtype), runtime(runtime) {}
+
+void TensorBaseObj::dataMalloc(const Blob &blob) {
+    IT_ASSERT(data == nullptr);
+    data = blob;
+    notifyCaptureState(true);
+}
+
+void TensorBaseObj::freeData() {
+    if (!data)
+        return;
+    data.reset();
+    notifyCaptureState(true);
+}
+
+void TensorBaseObj::registerCaptureState(
+    const Ref<GraphCaptureStateObj> &state) {
+    const auto stateId = state->getId();
+    for (auto it = captureStates.begin(); it != captureStates.end();) {
+        if (auto current = it->lock()) {
+            if (current->getId() == stateId)
+                return;
+            ++it;
+        } else {
+            it = captureStates.erase(it);
+        }
+    }
+    captureStates.emplace_back(state);
+}
+
+void TensorBaseObj::unregisterCaptureState(uint64_t stateId) {
+    captureStates.erase(
+        std::remove_if(captureStates.begin(), captureStates.end(),
+                       [stateId](const auto &state) {
+                           auto current = state.lock();
+                           return !current || current->getId() == stateId;
+                       }),
+        captureStates.end());
+}
+
+void TensorBaseObj::notifyCaptureState(bool storageChanged) {
+    for (auto it = captureStates.begin(); it != captureStates.end();) {
+        if (auto state = it->lock()) {
+            state->markChanged(storageChanged);
+            ++it;
+        } else {
+            it = captureStates.erase(it);
+        }
+    }
+}
 
 }; // namespace infini

--- a/src/cuda/cuda_runtime.cc
+++ b/src/cuda/cuda_runtime.cc
@@ -7,6 +7,8 @@
 #endif
 #include "operators/conv.h"
 #include "operators/matmul.h"
+#include <algorithm>
+#include <cstdio>
 
 void CHECK_CUDA_KERNEL_ERROR(infini::Operator op) {
     cudaError_t kernelError = cudaGetLastError();
@@ -19,18 +21,174 @@ void CHECK_CUDA_KERNEL_ERROR(infini::Operator op) {
 }
 
 namespace infini {
-void CudaRuntimeObj::runWithoutSync(const Graph &graph) const {
+
+namespace {
+void logCudaCleanupError(const char *operation, cudaError_t error) noexcept {
+    if (error != cudaSuccess)
+        std::fprintf(stderr, "%s failed: %s\n", operation,
+                     cudaGetErrorString(error));
+}
+
+void logCudnnCleanupError(const char *operation, cudnnStatus_t error) noexcept {
+    if (error != CUDNN_STATUS_SUCCESS)
+        std::fprintf(stderr, "%s failed: %s\n", operation,
+                     cudnnGetErrorString(error));
+}
+
+void logCublasCleanupError(const char *operation,
+                           cublasStatus_t error) noexcept {
+    if (error != CUBLAS_STATUS_SUCCESS)
+        std::fprintf(stderr, "%s failed: %s\n", operation,
+                     cublasGetErrorString(error));
+}
+
+void checkCublasStatus(cublasStatus_t status, const char *operation) {
+    if (status != CUBLAS_STATUS_SUCCESS)
+        throw Exception(std::string(operation) +
+                        " failed: " + cublasGetErrorString(status));
+}
+} // namespace
+
+bool CudaRuntimeObj::CapturedTensorState::operator==(
+    const CapturedTensorState &other) const {
+    return tensor == other.tensor && dtype == other.dtype &&
+           shape == other.shape && tensorBytes == other.tensorBytes &&
+           storageId == other.storageId &&
+           storageOffset == other.storageOffset &&
+           blobBytes == other.blobBytes && address == other.address;
+}
+
+bool CudaRuntimeObj::CapturedGraphState::operator==(
+    const CapturedGraphState &other) const {
+    return graphId == other.graphId && topologyEpoch == other.topologyEpoch &&
+           tensors == other.tensors;
+}
+
+CudaRuntimeObj::CudaGraphCacheEntry::~CudaGraphCacheEntry() noexcept {
+    if (instance)
+        logCudaCleanupError("cudaGraphExecDestroy",
+                            cudaGraphExecDestroy(instance));
+    if (graph)
+        logCudaCleanupError("cudaGraphDestroy", cudaGraphDestroy(graph));
+}
+
+CudaRuntimeObj::CudaRuntimeObj(int deviceId, size_t cudaGraphCacheCapacity)
+    : RuntimeObj(Device::CUDA, deviceId),
+      cudaGraphCacheCapacity(cudaGraphCacheCapacity) {
+    IT_ASSERT(cudaGraphCacheCapacity > 0,
+              "CUDA Graph cache capacity must be greater than zero");
+    try {
+        activateDevice();
+        checkCudaError(cudaStreamCreate(&stream));
+        checkCudnnError(cudnnCreate(&cudnn));
+        checkCublasStatus(cublasCreate(&cublas), "cublasCreate");
+        bindLibraryHandlesToStream();
+        workspace = alloc(workspaceSize);
+    } catch (...) {
+        if (workspace)
+            logCudaCleanupError("cudaFree(workspace)", cudaFree(workspace));
+        if (cublas)
+            logCublasCleanupError("cublasDestroy", cublasDestroy(cublas));
+        if (cudnn)
+            logCudnnCleanupError("cudnnDestroy", cudnnDestroy(cudnn));
+        if (stream)
+            logCudaCleanupError("cudaStreamDestroy", cudaStreamDestroy(stream));
+        throw;
+    }
+}
+
+CudaRuntimeObj::~CudaRuntimeObj() {
+    std::lock_guard<std::recursive_mutex> executionLock(executionMutex);
+    std::lock_guard<std::recursive_mutex> cacheLock(cacheMutex);
+    logCudaCleanupError("cudaSetDevice", cudaSetDevice(deviceId));
+    if (stream)
+        logCudaCleanupError("cudaStreamSynchronize",
+                            cudaStreamSynchronize(stream));
+    clearCudaGraphCacheImpl();
+    comm.reset();
+    if (workspace) {
+        logCudaCleanupError("cudaFree(workspace)", cudaFree(workspace));
+        workspace = nullptr;
+    }
+    if (cublas) {
+        logCublasCleanupError("cublasDestroy", cublasDestroy(cublas));
+        cublas = nullptr;
+    }
+    if (cudnn) {
+        logCudnnCleanupError("cudnnDestroy", cudnnDestroy(cudnn));
+        cudnn = nullptr;
+    }
+    if (stream) {
+        logCudaCleanupError("cudaStreamDestroy", cudaStreamDestroy(stream));
+        stream = nullptr;
+    }
+}
+
+void CudaRuntimeObj::activateDevice() const {
+    checkCudaError(cudaSetDevice(deviceId));
+}
+
+void CudaRuntimeObj::bindLibraryHandlesToStream() const {
+    checkCudnnError(cudnnSetStream(cudnn, stream));
+    checkCublasStatus(cublasSetStream(cublas, stream), "cublasSetStream");
+}
+
+void CudaRuntimeObj::ensureExecutionStream() const {
+    if (stream)
+        return;
+    checkCudaError(cudaStreamCreate(&stream));
+    try {
+        bindLibraryHandlesToStream();
+    } catch (...) {
+        logCudaCleanupError("cudaStreamDestroy after binding failure",
+                            cudaStreamDestroy(stream));
+        stream = nullptr;
+        throw;
+    }
+}
+
+CudaPtr CudaRuntimeObj::alloc(size_t size) {
+    activateDevice();
+    void *ptr = nullptr;
+    checkCudaError(cudaMalloc(&ptr, size));
+    return ptr;
+}
+
+void CudaRuntimeObj::dealloc(void *ptr) {
+    activateDevice();
+    checkCudaError(cudaFree(ptr));
+}
+
+void CudaRuntimeObj::copyBlobFromCPU(void *dst, const void *src,
+                                     size_t bytes) const {
+    activateDevice();
+    checkCudaError(cudaMemcpy(dst, src, bytes, cudaMemcpyHostToDevice));
+}
+
+void CudaRuntimeObj::copyBlobToCPU(void *dst, const void *src,
+                                   size_t bytes) const {
+    activateDevice();
+    checkCudaError(cudaMemcpy(dst, src, bytes, cudaMemcpyDeviceToHost));
+}
+
+void CudaRuntimeObj::copyBlobInsideRuntime(void *dst, const void *src,
+                                           size_t bytes) const {
+    activateDevice();
+    checkCudaError(cudaMemcpy(dst, src, bytes, cudaMemcpyDeviceToDevice));
+}
+
+void CudaRuntimeObj::runWithoutSyncImpl(const Graph &graph,
+                                        bool validate) const {
     IT_ASSERT(graph != nullptr, "Cannot run a null graph");
-    graph->validateMemory();
+    if (validate)
+        graph->validateMemory();
     const auto &kernelRegistry = KernelRegistry::getInstance();
     auto &perfEngine = PerfEngine::getInstance();
     for (auto &op : graph->getOperators()) {
-        // HACK: set correct data type
         auto kernelAttrs = KernelAttrs{device, op->getOpType().underlying()};
         Kernel *kernel = kernelRegistry.getKernel(kernelAttrs);
         auto perfKey = PerfEngine::Key{kernelAttrs, op->getOpPerfKey()};
         auto perfData = perfEngine.getPerfData(perfKey);
-        // IT_ASSERT(perfData, "No perf data for OP " + op->toString());
         if (perfData) {
             ComputeFuncPtr funcPtr = kernel->getComputeFunc(perfKey);
             funcPtr(op, perfData, this);
@@ -41,66 +199,233 @@ void CudaRuntimeObj::runWithoutSync(const Graph &graph) const {
     }
 }
 
-void CudaRuntimeObj::runWithCudaGraph(const Graph &graph) {
-    IT_ASSERT(graph != nullptr, "Cannot run a null graph");
-    graph->validateMemory();
-    if (!isCudaGraphCreated) {
-        vector<const TensorObj *> capturedTensors;
-        vector<const void *> capturedTensorAddresses;
-        vector<vector<int>> capturedTensorShapes;
-        capturedTensors.reserve(graph->getTensors().size());
-        capturedTensorAddresses.reserve(graph->getTensors().size());
-        capturedTensorShapes.reserve(graph->getTensors().size());
-        for (const auto &tensor : graph->getTensors()) {
-            capturedTensors.emplace_back(tensor.get());
-            capturedTensorAddresses.emplace_back(
-                tensor->getRawDataPtr<const void *>());
-            capturedTensorShapes.emplace_back(tensor->getDims());
-        }
-
-        CUDAStream::createStream();
-        checkCudnnError(cudnnSetStream(cudnn, CUDAStream::getCurrentStream()));
-        checkCublasError(
-            cublasSetStream(cublas, CUDAStream::getCurrentStream()));
-        checkCudaError(cudaStreamBeginCapture(CUDAStream::getCurrentStream(),
-                                              cudaStreamCaptureModeGlobal));
-        runWithoutSync(graph);
-        checkCudaError(
-            cudaStreamEndCapture(CUDAStream::getCurrentStream(), &cudaGraph));
-        checkCudaError(
-            cudaGraphInstantiate(&cudaGraphInstance, cudaGraph, NULL, NULL, 0));
-        isCudaGraphCreated = true;
-        cudaGraphOwner = graph;
-        cudaGraphAllocationGeneration = graph->getAllocationGeneration();
-        cudaGraphTensors = std::move(capturedTensors);
-        cudaGraphTensorAddresses = std::move(capturedTensorAddresses);
-        cudaGraphTensorShapes = std::move(capturedTensorShapes);
-    } else {
-        auto owner = cudaGraphOwner.lock();
-        IT_ASSERT(owner && owner.get() == graph.get(),
-                  "CUDA Graph was captured for a different graph");
-        IT_ASSERT(cudaGraphAllocationGeneration ==
-                      graph->getAllocationGeneration(),
-                  "CUDA Graph memory changed after capture; capture a new "
-                  "runtime before replay");
-        const auto &tensors = graph->getTensors();
-        IT_ASSERT(cudaGraphTensors.size() == tensors.size(),
-                  "CUDA Graph tensor set changed after capture");
-        for (size_t i = 0; i < tensors.size(); ++i) {
-            IT_ASSERT(cudaGraphTensors[i] == tensors[i].get() &&
-                          cudaGraphTensorAddresses[i] ==
-                              tensors[i]->getRawDataPtr<const void *>() &&
-                          cudaGraphTensorShapes[i] == tensors[i]->getDims(),
-                      "CUDA Graph tensor memory or shape changed after "
-                      "capture; capture a new runtime before replay");
-        }
-        checkCudaError(
-            cudaGraphLaunch(cudaGraphInstance, CUDAStream::getCurrentStream()));
-    }
-    checkCudaError(cudaStreamSynchronize(CUDAStream::getCurrentStream()));
+void CudaRuntimeObj::runWithoutSync(const Graph &graph) const {
+    std::lock_guard<std::recursive_mutex> lock(executionMutex);
+    activateDevice();
+    ensureExecutionStream();
+    CUDAStream::Guard streamGuard(stream);
+    runWithoutSyncImpl(graph, true);
 }
 
-void CudaRuntimeObj::tune(const Graph &graph, bool profiling = false) const {
+CudaRuntimeObj::CapturedGraphState
+CudaRuntimeObj::captureStateOf(const Graph &graph) const {
+    CapturedGraphState state{
+        graph->getCaptureStateId(), graph->getTopologyEpoch(), {}};
+    state.tensors.reserve(graph->getTensors().size());
+    for (const auto &tensor : graph->getTensors()) {
+        const auto &blob = tensor->getDataBlob();
+        IT_ASSERT(blob != nullptr, "Cannot capture a Tensor without memory");
+        state.tensors.emplace_back(CapturedTensorState{
+            tensor.get(), tensor->getDTypeIndex(), tensor->getDims(),
+            tensor->getBytes(), blob->getStorageId(), blob->getStorageOffset(),
+            blob->getBytes(), tensor->getRawDataPtr<const void *>()});
+    }
+    return state;
+}
+
+void CudaRuntimeObj::recoverExecutionStreamAfterFailure() noexcept {
+    cudaGetLastError();
+    if (stream)
+        logCudaCleanupError("cudaStreamDestroy after capture failure",
+                            cudaStreamDestroy(stream));
+    stream = nullptr;
+    auto status = cudaStreamCreate(&stream);
+    if (status != cudaSuccess) {
+        logCudaCleanupError("cudaStreamCreate after capture failure", status);
+        cudaGetLastError();
+        return;
+    }
+    const auto cudnnStatus = cudnnSetStream(cudnn, stream);
+    const auto cublasStatus = cublasSetStream(cublas, stream);
+    logCudnnCleanupError("cudnnSetStream after capture failure", cudnnStatus);
+    logCublasCleanupError("cublasSetStream after capture failure",
+                          cublasStatus);
+    if (cudnnStatus != CUDNN_STATUS_SUCCESS ||
+        cublasStatus != CUBLAS_STATUS_SUCCESS) {
+        logCudaCleanupError("cudaStreamDestroy after rebinding failure",
+                            cudaStreamDestroy(stream));
+        stream = nullptr;
+    }
+    cudaGetLastError();
+}
+
+std::unique_ptr<CudaRuntimeObj::CudaGraphCacheEntry>
+CudaRuntimeObj::captureGraph(const Graph &graph, CapturedGraphState state) {
+    auto entry = std::make_unique<CudaGraphCacheEntry>(WRef<GraphObj>(graph),
+                                                       std::move(state));
+    bool captureStarted = false;
+    try {
+        checkCudaError(
+            cudaStreamBeginCapture(stream, cudaStreamCaptureModeThreadLocal));
+        captureStarted = true;
+        runWithoutSyncImpl(graph, false);
+        auto endStatus = cudaStreamEndCapture(stream, &entry->graph);
+        captureStarted = false;
+        checkCudaError(endStatus);
+        checkCudaError(cudaGraphInstantiate(&entry->instance, entry->graph,
+                                            nullptr, nullptr, 0));
+    } catch (...) {
+        auto originalError = std::current_exception();
+        if (captureStarted) {
+            cudaGraph_t abandonedGraph = nullptr;
+            auto endStatus = cudaStreamEndCapture(stream, &abandonedGraph);
+            if (abandonedGraph)
+                logCudaCleanupError("cudaGraphDestroy after capture failure",
+                                    cudaGraphDestroy(abandonedGraph));
+            if (endStatus != cudaSuccess)
+                logCudaCleanupError("cudaStreamEndCapture after failure",
+                                    endStatus);
+        }
+        recoverExecutionStreamAfterFailure();
+        std::rethrow_exception(originalError);
+    }
+    return entry;
+}
+
+void CudaRuntimeObj::markActiveGraph(CudaGraphCache::iterator entry,
+                                     size_t generation) {
+    activeCudaGraphs.insert_or_assign((*entry)->state.graphId,
+                                      ActiveCudaGraphState{entry, generation});
+}
+
+void CudaRuntimeObj::clearActiveGraph(
+    const CudaGraphCacheEntry *entry) noexcept {
+    const auto active = activeCudaGraphs.find(entry->state.graphId);
+    if (active != activeCudaGraphs.end() &&
+        active->second.entry->get() == entry)
+        activeCudaGraphs.erase(active);
+}
+
+void CudaRuntimeObj::purgeExpiredGraphCacheEntries() noexcept {
+    for (auto it = cudaGraphCache.begin(); it != cudaGraphCache.end();) {
+        if ((*it)->owner.expired()) {
+            clearActiveGraph(it->get());
+            it = cudaGraphCache.erase(it);
+        } else {
+            ++it;
+        }
+    }
+}
+
+void CudaRuntimeObj::eraseGraphCacheEntries(uint64_t graphId) noexcept {
+    activeCudaGraphs.erase(graphId);
+    for (auto it = cudaGraphCache.begin(); it != cudaGraphCache.end();) {
+        if ((*it)->state.graphId == graphId) {
+            it = cudaGraphCache.erase(it);
+        } else {
+            ++it;
+        }
+    }
+}
+
+void CudaRuntimeObj::clearCudaGraphCacheImpl() noexcept {
+    activeCudaGraphs.clear();
+    cudaGraphCache.clear();
+}
+
+void CudaRuntimeObj::invalidateGraphCaptureCache(uint64_t graphId) noexcept {
+    std::lock_guard<std::recursive_mutex> executionLock(executionMutex);
+    std::lock_guard<std::recursive_mutex> cacheLock(cacheMutex);
+    logCudaCleanupError("cudaSetDevice during CUDA Graph invalidation",
+                        cudaSetDevice(deviceId));
+    eraseGraphCacheEntries(graphId);
+}
+
+void CudaRuntimeObj::clearCudaGraphCache() {
+    std::lock_guard<std::recursive_mutex> executionLock(executionMutex);
+    std::lock_guard<std::recursive_mutex> cacheLock(cacheMutex);
+    activateDevice();
+    clearCudaGraphCacheImpl();
+}
+
+size_t CudaRuntimeObj::getCudaGraphCacheSize() const {
+    std::lock_guard<std::recursive_mutex> lock(cacheMutex);
+    return cudaGraphCache.size();
+}
+
+size_t CudaRuntimeObj::getCudaGraphCaptureCount() const {
+    std::lock_guard<std::recursive_mutex> lock(cacheMutex);
+    return cudaGraphCaptureCount;
+}
+
+void CudaRuntimeObj::runWithCudaGraph(const Graph &graph) {
+    IT_ASSERT(graph != nullptr, "Cannot run a null graph");
+    std::lock_guard<std::recursive_mutex> executionLock(executionMutex);
+    activateDevice();
+    ensureExecutionStream();
+    CUDAStream::Guard streamGuard(stream);
+    std::lock_guard<std::recursive_mutex> cacheLock(cacheMutex);
+
+    const auto generation = graph->getCaptureGeneration();
+    const auto graphId = graph->getCaptureStateId();
+    const auto active = activeCudaGraphs.find(graphId);
+    if (active != activeCudaGraphs.end() &&
+        active->second.generation == generation) {
+        auto cacheEntry = active->second.entry;
+        auto *entry = cacheEntry->get();
+        auto owner = entry->owner.lock();
+        if (owner && owner.get() == graph.get()) {
+            cudaGraphCache.splice(cudaGraphCache.begin(), cudaGraphCache,
+                                  cacheEntry);
+            try {
+                checkCudaError(cudaGraphLaunch(entry->instance, stream));
+                syncImpl();
+            } catch (...) {
+                auto originalError = std::current_exception();
+                eraseGraphCacheEntries(graph->getCaptureStateId());
+                recoverExecutionStreamAfterFailure();
+                std::rethrow_exception(originalError);
+            }
+            return;
+        }
+    }
+
+    purgeExpiredGraphCacheEntries();
+    graph->validateMemory();
+    auto state = captureStateOf(graph);
+    auto hit = std::find_if(cudaGraphCache.begin(), cudaGraphCache.end(),
+                            [&state, &graph](const auto &entry) {
+                                auto owner = entry->owner.lock();
+                                return owner && owner.get() == graph.get() &&
+                                       entry->state == state;
+                            });
+    if (hit != cudaGraphCache.end()) {
+        auto *entry = hit->get();
+        cudaGraphCache.splice(cudaGraphCache.begin(), cudaGraphCache, hit);
+        markActiveGraph(hit, generation);
+        try {
+            checkCudaError(cudaGraphLaunch(entry->instance, stream));
+            syncImpl();
+        } catch (...) {
+            auto originalError = std::current_exception();
+            eraseGraphCacheEntries(graph->getCaptureStateId());
+            recoverExecutionStreamAfterFailure();
+            std::rethrow_exception(originalError);
+        }
+        return;
+    }
+
+    auto entry = captureGraph(graph, std::move(state));
+    IT_ASSERT(generation == graph->getCaptureGeneration(),
+              "Graph changed while CUDA Graph capture was in progress");
+    try {
+        checkCudaError(cudaGraphLaunch(entry->instance, stream));
+        syncImpl();
+    } catch (...) {
+        auto originalError = std::current_exception();
+        recoverExecutionStreamAfterFailure();
+        std::rethrow_exception(originalError);
+    }
+    ++cudaGraphCaptureCount;
+    cudaGraphCache.emplace_front(std::move(entry));
+    markActiveGraph(cudaGraphCache.begin(), generation);
+    while (cudaGraphCache.size() > cudaGraphCacheCapacity) {
+        clearActiveGraph(cudaGraphCache.back().get());
+        cudaGraphCache.pop_back();
+    }
+}
+
+void CudaRuntimeObj::tune(const Graph &graph, bool profiling) const {
     IT_ASSERT(graph != nullptr, "Cannot tune a null graph");
     graph->validateMemory();
     const auto &kernelRegistry = KernelRegistry::getInstance();
@@ -109,7 +434,6 @@ void CudaRuntimeObj::tune(const Graph &graph, bool profiling = false) const {
     std::map<OpType, double> opTime;
     std::map<OpType, int> opCnt;
     for (auto &op : graph->getOperators()) {
-        // HACK: set correct data type
         auto kernelAttrs = KernelAttrs{device, op->getOpType().underlying()};
         Kernel *kernel = kernelRegistry.getKernel(kernelAttrs);
         auto perfKey = PerfEngine::Key{kernelAttrs, op->getOpPerfKey()};
@@ -118,44 +442,61 @@ void CudaRuntimeObj::tune(const Graph &graph, bool profiling = false) const {
         if (!perfData) {
             record = kernel->tune(op, this);
             perfEngine.setPerfData(perfKey, record);
-        } else
+        } else {
             record = perfData;
-        double t = record->time;
-        totalTime += t;
-        json j;
-
+        }
+        const double recordedTime = record->time;
+        totalTime += recordedTime;
         kernel->computeFuncTune(perfKey, op, record, this);
         if (profiling) {
             ComputeFuncPtr funcPtr = kernel->getComputeFunc(perfKey);
-            double t = timeit([&]() { funcPtr(op, record, this); },
-                              [&]() { sync(); }, 1, 1);
+            const double measuredTime =
+                timeit([&]() { funcPtr(op, record, this); },
+                       [&]() { syncImpl(); }, 1, 1);
             op->print();
-            printf(" op_time on cuda %lf\n", t);
-            totalTime += t;
-            opTime[op->getOpType()] += t;
+            printf(" op_time on cuda %lf\n", measuredTime);
+            totalTime += measuredTime;
+            opTime[op->getOpType()] += measuredTime;
             opCnt[op->getOpType()]++;
         }
-
         checkCudaError(cudaGetLastError()) << op->toString();
     }
 }
 
 void CudaRuntimeObj::run(const Graph &graph, bool runTune,
                          bool profiling) const {
+    std::lock_guard<std::recursive_mutex> lock(executionMutex);
+    activateDevice();
+    ensureExecutionStream();
+    CUDAStream::Guard streamGuard(stream);
     if (profiling)
         IT_TODO_HALT();
     if (runTune)
         tune(graph, profiling);
     else
-        runWithoutSync(graph);
-    sync();
+        runWithoutSyncImpl(graph, true);
+    syncImpl();
 }
 
-void CudaRuntimeObj::sync() const { checkCudaError(cudaDeviceSynchronize()); }
+void CudaRuntimeObj::syncImpl() const {
+    checkCudaError(cudaStreamSynchronize(stream));
+}
+
+void CudaRuntimeObj::sync() const {
+    std::lock_guard<std::recursive_mutex> lock(executionMutex);
+    activateDevice();
+    ensureExecutionStream();
+    CUDAStream::Guard streamGuard(stream);
+    syncImpl();
+}
 
 string CudaRuntimeObj::toString() const { return "CUDA Runtime"; }
 
 void CudaRuntimeObj::initComm(const string &name, int worldSize, int rank) {
+    std::lock_guard<std::recursive_mutex> lock(executionMutex);
+    activateDevice();
+    ensureExecutionStream();
+    CUDAStream::Guard streamGuard(stream);
     IT_ASSERT(worldSize > 0);
     IT_ASSERT(rank >= 0);
     IT_ASSERT(rank < worldSize);
@@ -167,5 +508,5 @@ void CudaRuntimeObj::initComm(const string &name, int worldSize, int rank) {
 #endif
 }
 
-cudaStream_t CUDAStream::_stream = 0;
+thread_local cudaStream_t CUDAStream::_stream = nullptr;
 } // namespace infini

--- a/src/ffi/ffi_infinitensor.cc
+++ b/src/ffi/ffi_infinitensor.cc
@@ -167,8 +167,9 @@ static int tensor_dtype(Tensor t) {
 
 #ifdef USE_CUDA
 // NOTE(lizhouyang): deprecate this, use CudaRuntime directly.
-[[deprecated]] static Ref<CudaRuntimeObj> cuda_runtime() {
-    return make_ref<CudaRuntimeObj>(0);
+[[deprecated]] static Ref<CudaRuntimeObj>
+cuda_runtime(int device = 0, size_t cudaGraphCacheCapacity = 16) {
+    return make_ref<CudaRuntimeObj>(device, cudaGraphCacheCapacity);
 }
 #endif
 
@@ -356,13 +357,11 @@ void export_functions(py::module &m) {
 #define FUNCTION(NAME) def(#NAME, &NAME)
     m.def("cpu_runtime", &NativeCpuRuntimeObj::getInstance)
 #ifdef USE_CUDA
-        .def("cuda_runtime", cuda_runtime)
+        .def("cuda_runtime", cuda_runtime, py::arg("device") = 0,
+             py::arg("cuda_graph_cache_capacity") = 16)
 #endif
 #ifdef USE_INTELCPU
         .def("intelcpu_runtime", intelcpu_runtime)
-#endif
-#ifdef USE_CUDA
-        .FUNCTION(cuda_runtime)
 #endif
 #ifdef USE_BANG
         .FUNCTION(bang_runtime)
@@ -448,7 +447,12 @@ void init_graph_builder(py::module &m) {
 #ifdef USE_CUDA
     py::class_<CudaRuntimeObj, std::shared_ptr<CudaRuntimeObj>, RuntimeObj>(
         m, "CudaRuntime")
-        .def(py::init<int>(), py::arg("device") = 0)
+        .def(py::init<int, size_t>(), py::arg("device") = 0,
+             py::arg("cuda_graph_cache_capacity") = 16)
+        .def("clear_cuda_graph_cache", &CudaRuntimeObj::clearCudaGraphCache)
+        .def("cuda_graph_cache_size", &CudaRuntimeObj::getCudaGraphCacheSize)
+        .def("cuda_graph_capture_count",
+             &CudaRuntimeObj::getCudaGraphCaptureCount)
         .def("init_comm", &CudaRuntimeObj::initComm);
 #endif
 #ifdef USE_BANG

--- a/src/kernels/cuda/batch_norm.cc
+++ b/src/kernels/cuda/batch_norm.cc
@@ -20,20 +20,19 @@ class BatchNormCudnn : public CudaKernelWithoutConfig {
 
         // Only 4D and 5D tensors are supported by
         // cudnnBatchNormalizationForwardInference
-        if (auto dims = op->getInputs(0)->getDims(); dims.size() < 4) {
-            auto dims_t = dims;
-            for (size_t i = dims_t.size(); i < 4; ++i) {
-                dims_t.push_back(1);
-            }
-            op->getInputs(0)->setShape(dims_t);
-        }
         auto dims = op->getInputs(0)->getDims();
+        for (size_t i = dims.size(); i < 4; ++i)
+            dims.push_back(1);
         IT_ASSERT(dims.size() == 4);
 
         int dimArray[4], strideArray[4], dimPArray[4], stridePArray[4];
+        int stride = 1;
+        for (int i = static_cast<int>(dims.size()) - 1; i >= 0; --i) {
+            strideArray[i] = stride;
+            stride *= dims[i];
+        }
         for (size_t i = 0; i < dims.size(); ++i) {
             dimArray[i] = dims[i];
-            strideArray[i] = op->getInputs(0)->getStride()[i];
             dimPArray[i] = 1;
             stridePArray[i] = 1;
         }

--- a/src/kernels/cuda/unary.cu
+++ b/src/kernels/cuda/unary.cu
@@ -373,7 +373,8 @@ void leaky_relu_kernel(T *input, T *output, size_t num, float alphaValue) {
 void elu_kernel(const float *input, float *output, size_t size, float alpha) {
     int blocksize = 32 * 16;
     int gridsize = (size + blocksize - 1) / blocksize;
-    _elu_kernel<<<gridsize, blocksize>>>(input, output, size, alpha);
+    _elu_kernel<<<gridsize, blocksize, 0, CUDAStream::getCurrentStream()>>>(
+        input, output, size, alpha);
 }
 
 template void cast_kernel<float, half>(float *input, half *output, size_t num);

--- a/test/core/test_graph.cc
+++ b/test/core/test_graph.cc
@@ -101,6 +101,72 @@ TEST(Graph, build_and_run) {
     EXPECT_TRUE(o0->equalData(ans));
 }
 
+TEST(Graph, blob_views_preserve_storage_identity) {
+    auto runtime = make_ref<TrackingCpuRuntimeObj>();
+    {
+        auto storage = runtime->allocBlob(64);
+        auto view = make_ref<BlobObj>(storage, 16, 32);
+        auto nestedView = make_ref<BlobObj>(view, 8, 8);
+        auto otherStorage = runtime->allocBlob(64);
+
+        EXPECT_EQ(view->getStorageId(), storage->getStorageId());
+        EXPECT_EQ(view->getStorageOffset(), 16u);
+        EXPECT_EQ(nestedView->getStorageId(), storage->getStorageId());
+        EXPECT_EQ(nestedView->getStorageOffset(), 24u);
+        EXPECT_NE(otherStorage->getStorageId(), storage->getStorageId());
+    }
+    EXPECT_EQ(runtime->getLiveAllocationCount(), 0u);
+}
+
+TEST(Graph, capture_generation_tracks_execution_state) {
+    auto runtime = make_ref<TrackingCpuRuntimeObj>();
+    Graph g = make_ref<GraphObj>(runtime);
+    auto input = g->addTensor({4}, DataType::Float32);
+    input->setInput();
+    g->dataMalloc();
+
+    const auto stableGeneration = g->getCaptureGeneration();
+    const auto stableTopology = g->getTopologyEpoch();
+    input->setShape({4});
+    input->copyin(vector<float>{1, 2, 3, 4});
+    EXPECT_EQ(g->getCaptureGeneration(), stableGeneration);
+    EXPECT_EQ(g->getTopologyEpoch(), stableTopology);
+
+    input->setShape({2, 2});
+    EXPECT_GT(g->getCaptureGeneration(), stableGeneration);
+    EXPECT_EQ(g->getTopologyEpoch(), stableTopology);
+
+    const auto layoutGeneration = g->getCaptureGeneration();
+    auto unallocated = g->addTensor({1}, DataType::Float32);
+    EXPECT_GT(g->getCaptureGeneration(), layoutGeneration);
+    EXPECT_GT(g->getTopologyEpoch(), stableTopology);
+
+    const auto generationBeforeFailure = g->getCaptureGeneration();
+    runtime->failNextAlloc();
+    EXPECT_THROW(unallocated->dataMalloc(), std::bad_alloc);
+    EXPECT_EQ(g->getCaptureGeneration(), generationBeforeFailure);
+}
+
+TEST(Graph, shared_tensor_notifies_each_graph_with_weak_observers) {
+    auto runtime = make_ref<TrackingCpuRuntimeObj>();
+    auto tensor = make_ref<TensorObj>(Shape{2}, DataType::Float32, runtime);
+    Graph first = make_ref<GraphObj>(runtime);
+    Graph second = make_ref<GraphObj>(runtime);
+    first->addTensor(tensor);
+    second->addTensor(tensor);
+    const auto firstGeneration = first->getCaptureGeneration();
+    const auto secondGeneration = second->getCaptureGeneration();
+
+    tensor->setShape({1, 2});
+    EXPECT_GT(first->getCaptureGeneration(), firstGeneration);
+    EXPECT_GT(second->getCaptureGeneration(), secondGeneration);
+
+    first.reset();
+    const auto remainingGeneration = second->getCaptureGeneration();
+    tensor->setShape({2, 1});
+    EXPECT_GT(second->getCaptureGeneration(), remainingGeneration);
+}
+
 TEST(Graph, naive_allocator_reallocates_dynamic_tensors) {
     Runtime runtime = NativeCpuRuntimeObj::getInstance();
     Graph g = make_ref<GraphObj>(runtime);
@@ -309,6 +375,7 @@ TEST(Graph, lazy_allocator_trim_failure_preserves_committed_layout) {
         const auto inputAddress = input->getRawDataPtr<const void *>();
         const auto outputAddress = output->getRawDataPtr<const void *>();
         const auto generation = g->getAllocationGeneration();
+        const auto captureGeneration = g->getCaptureGeneration();
         const auto liveAllocations = runtime->getLiveAllocationCount();
 
         runtime->failNextAlloc();
@@ -316,6 +383,7 @@ TEST(Graph, lazy_allocator_trim_failure_preserves_committed_layout) {
         EXPECT_EQ(input->getRawDataPtr<const void *>(), inputAddress);
         EXPECT_EQ(output->getRawDataPtr<const void *>(), outputAddress);
         EXPECT_EQ(g->getAllocationGeneration(), generation);
+        EXPECT_EQ(g->getCaptureGeneration(), captureGeneration);
         EXPECT_EQ(runtime->getLiveAllocationCount(), liveAllocations);
 
         runtime->failNextBlobCopy();
@@ -323,6 +391,7 @@ TEST(Graph, lazy_allocator_trim_failure_preserves_committed_layout) {
         EXPECT_EQ(input->getRawDataPtr<const void *>(), inputAddress);
         EXPECT_EQ(output->getRawDataPtr<const void *>(), outputAddress);
         EXPECT_EQ(g->getAllocationGeneration(), generation);
+        EXPECT_EQ(g->getCaptureGeneration(), captureGeneration);
         EXPECT_EQ(runtime->getLiveAllocationCount(), liveAllocations);
 
         runtime->run(g);

--- a/test/cuda/test_cudagraph.cc
+++ b/test/cuda/test_cudagraph.cc
@@ -1,96 +1,320 @@
 #include "core/graph.h"
+#include "core/kernel.h"
 #include "core/runtime.h"
+#include "cuda/cuda_kernel_wihtout_config.h"
 #include "cuda/cuda_runtime.h"
-#include "cuda/cuda_utility.h"
-#include "operators/attention_kvcache.h"
+#include "operators/dropout.h"
+#include "operators/matmul.h"
+#include "operators/unary.h"
 
 #include "test.h"
+#include <algorithm>
+#include <atomic>
+#include <thread>
 
 namespace infini {
 
-TEST(TestCudaRuntime, CudaGraph) {
-    Runtime runtime = NativeCpuRuntimeObj::getInstance();
+namespace {
+class CaptureUnsupportedKernel : public CudaKernelWithoutConfig {
+    void compute(const Operator &, const RuntimeObj *) const override {
+        checkCudaError(cudaStreamSynchronize(CUDAStream::getCurrentStream()));
+    }
+};
 
-    Graph gCpu = make_ref<GraphObj>(runtime);
+[[maybe_unused]] const bool captureUnsupportedKernelRegistered =
+    KernelRegistry::getInstance().registerKernel(
+        KernelAttrs{Device::CUDA, OpType::Dropout},
+        new CaptureUnsupportedKernel(), "CaptureUnsupportedKernel");
 
-    auto cudaRuntime = make_ref<CudaRuntimeObj>();
-    Graph gCuda = make_ref<GraphObj>(cudaRuntime);
+class CudaGraphFixture {
+  public:
+    Ref<CudaRuntimeObj> runtime;
+    Graph graph;
+    Tensor input;
+    Tensor weight;
+    Tensor output;
 
-    auto input_k_cache_d = gCuda->addTensor({1, 1, 1, 128}, DataType::Float32);
-    auto input_v_cache_d = gCuda->addTensor({1, 1, 1, 128}, DataType::Float32);
-    auto input_q_d = gCuda->addTensor({1, 1, 1, 128}, DataType::Float32);
-    auto input_k_d = gCuda->addTensor({1, 1, 1, 128}, DataType::Float32);
-    auto input_v_d = gCuda->addTensor({1, 1, 1, 128}, DataType::Float32);
-    auto position_id_d = gCuda->addTensor({1, 1}, DataType::UInt32);
+    explicit CudaGraphFixture(Ref<CudaRuntimeObj> runtime, int batch = 8)
+        : runtime(std::move(runtime)),
+          graph(make_ref<GraphObj>(this->runtime)) {
+        input = graph->addTensor({batch, 2}, DataType::Float32);
+        weight = graph->addTensor({2, 2}, DataType::Float32);
+        input->setInput();
+        weight->setWeight();
+        auto matmul = graph->addOp<MatmulObj>(input, weight, nullptr);
+        output =
+            graph->addOp<ReluObj>(matmul->getOutput(), nullptr)->getOutput();
+        output->setOutput();
+        graph->dataMalloc();
+        weight->copyin(vector<float>{1, 0, 0, 1});
+    }
 
-    auto op = gCuda->addOp<AttentionKVCacheObj>(
-        input_k_cache_d, input_v_cache_d, input_q_d, input_k_d, input_v_d,
-        position_id_d, nullptr);
-    auto op1 = gCuda->addOp<AttentionKVCacheObj>(
-        input_k_cache_d, input_v_cache_d, op->getOutputs()[0], input_k_d,
-        input_v_d, position_id_d, nullptr);
-    auto op2 = gCuda->addOp<AttentionKVCacheObj>(
-        input_k_cache_d, input_v_cache_d, op1->getOutputs()[0], input_k_d,
-        input_v_d, position_id_d, nullptr);
-    gCuda->dataMalloc();
+    void reshape(int batch) {
+        if (input->getDims() == Shape{batch, 2})
+            return;
+        input->setShape({batch, 2});
+        graph->shape_infer();
+        graph->dataMalloc();
+    }
 
-    input_q_d->setData(OneGenerator());
-    input_k_d->setData(OneGenerator());
-    input_v_d->setData(OneGenerator());
-    position_id_d->setData(IncrementalGenerator());
+    void run(const vector<float> &values) {
+        IT_ASSERT(values.size() == input->size());
+        input->copyin(values);
+        runtime->runWithCudaGraph(graph);
+    }
 
-    cudaRuntime->run(gCuda);
+    bool outputEquals(const vector<float> &expected) const {
+        return output->clone(NativeCpuRuntimeObj::getInstance())
+            ->equalData(expected);
+    }
+};
 
-    cudaEvent_t start, stop;
-    float milliseconds_1 = 0, milliseconds_2 = 0;
-    cudaEventCreate(&start);
-    cudaEventCreate(&stop);
+vector<float> increasingValues(int batch, float offset = 0) {
+    vector<float> values(batch * 2);
+    for (size_t i = 0; i < values.size(); ++i)
+        values[i] = static_cast<float>(i) + offset;
+    return values;
+}
+} // namespace
 
-    cudaDeviceSynchronize();
-    cudaEventRecord(start);
-    cudaRuntime->run(gCuda);
-    cudaEventRecord(stop);
-    cudaEventSynchronize(stop);
-    cudaEventElapsedTime(&milliseconds_1, start, stop);
-    printf("without cudaGraph, latency: %f ms\n", milliseconds_1);
+TEST(TestCudaRuntime, CudaGraphCapturesFirstRunAndReplays) {
+    auto runtime = make_ref<CudaRuntimeObj>();
+    CudaGraphFixture fixture(runtime);
 
-    cudaRuntime->runWithCudaGraph(gCuda);
-    cudaRuntime->runWithCudaGraph(gCuda);
+    auto values = increasingValues(8, -4);
+    fixture.run(values);
+    EXPECT_EQ(runtime->getCudaGraphCaptureCount(), 1u);
+    EXPECT_EQ(runtime->getCudaGraphCacheSize(), 1u);
 
-    const auto capturedGeneration = gCuda->getAllocationGeneration();
-    const auto capturedShape = input_q_d->getDims();
-    input_q_d->setShape({1, 1, 2, 64});
-    EXPECT_EQ(gCuda->getAllocationGeneration(), capturedGeneration);
-    EXPECT_THROW(cudaRuntime->runWithCudaGraph(gCuda), Exception);
-    input_q_d->setShape(capturedShape);
-    EXPECT_NO_THROW(cudaRuntime->runWithCudaGraph(gCuda));
+    vector<float> expected(values.size());
+    std::transform(values.begin(), values.end(), expected.begin(),
+                   [](float value) { return std::max(value, 0.0f); });
+    EXPECT_TRUE(fixture.outputEquals(expected));
 
-    const auto capturedBlob = input_q_d->getDataBlob();
-    const auto capturedAddress = input_q_d->getRawDataPtr<const void *>();
-    input_q_d->freeData();
-    input_q_d->dataMalloc();
-    EXPECT_EQ(gCuda->getAllocationGeneration(), capturedGeneration);
-    EXPECT_NE(input_q_d->getRawDataPtr<const void *>(), capturedAddress);
-    EXPECT_THROW(cudaRuntime->runWithCudaGraph(gCuda), Exception);
-    input_q_d->setDataBlob(capturedBlob);
-    EXPECT_NO_THROW(cudaRuntime->runWithCudaGraph(gCuda));
+    values = increasingValues(8, 1);
+    fixture.run(values);
+    EXPECT_EQ(runtime->getCudaGraphCaptureCount(), 1u);
+    EXPECT_TRUE(fixture.outputEquals(values));
+}
 
-    cudaDeviceSynchronize();
-    cudaEventRecord(start);
-    cudaRuntime->runWithCudaGraph(gCuda);
-    cudaEventRecord(stop);
-    cudaEventSynchronize(stop);
-    cudaEventElapsedTime(&milliseconds_2, start, stop);
-    printf("with cudaGraph, latency: %f ms\n", milliseconds_2);
-    EXPECT_GE(milliseconds_1, milliseconds_2);
+TEST(TestCudaRuntime, CudaGraphReusesPreviousShapeInSameStorage) {
+    auto runtime = make_ref<CudaRuntimeObj>();
+    CudaGraphFixture fixture(runtime, 8);
 
-    // Replanning an unchanged layout reuses the captured addresses.
-    const auto generationBeforeReplan = gCuda->getAllocationGeneration();
-    const auto addressBeforeReplan = input_q_d->getRawDataPtr<const void *>();
-    gCuda->dataMalloc();
-    EXPECT_EQ(gCuda->getAllocationGeneration(), generationBeforeReplan);
-    EXPECT_EQ(input_q_d->getRawDataPtr<const void *>(), addressBeforeReplan);
-    EXPECT_NO_THROW(cudaRuntime->runWithCudaGraph(gCuda));
+    fixture.run(increasingValues(8));
+    fixture.reshape(4);
+    fixture.run(increasingValues(4));
+    EXPECT_EQ(runtime->getCudaGraphCaptureCount(), 2u);
+
+    fixture.reshape(8);
+    auto values = increasingValues(8, 10);
+    fixture.run(values);
+    EXPECT_EQ(runtime->getCudaGraphCaptureCount(), 2u);
+    EXPECT_EQ(runtime->getCudaGraphCacheSize(), 2u);
+    EXPECT_TRUE(fixture.outputEquals(values));
+}
+
+TEST(TestCudaRuntime, CudaGraphIgnoresTensorContents) {
+    auto runtime = make_ref<CudaRuntimeObj>();
+    CudaGraphFixture fixture(runtime, 2);
+
+    fixture.run(vector<float>{1, -2, 3, -4});
+    fixture.weight->copyin(vector<float>{2, 0, 0, 3});
+    fixture.run(vector<float>{-1, 2, 3, -4});
+
+    EXPECT_EQ(runtime->getCudaGraphCaptureCount(), 1u);
+    EXPECT_TRUE(fixture.outputEquals(vector<float>{0, 6, 6, 0}));
+}
+
+TEST(TestCudaRuntime, CudaGraphCapturesEluOnRuntimeStream) {
+    auto runtime = make_ref<CudaRuntimeObj>();
+    Graph graph = make_ref<GraphObj>(runtime);
+    auto input = graph->addTensor({4}, DataType::Float32);
+    input->setInput();
+    auto output = graph->addOp<EluObj>(input, nullptr, 1.0f)->getOutput();
+    output->setOutput();
+    graph->dataMalloc();
+    input->copyin(vector<float>{-1, 0, 1, 2});
+
+    runtime->runWithCudaGraph(graph);
+    runtime->runWithCudaGraph(graph);
+    EXPECT_EQ(runtime->getCudaGraphCaptureCount(), 1u);
+    auto cpuOutput = output->clone(NativeCpuRuntimeObj::getInstance());
+    EXPECT_TRUE(cpuOutput->equalData(vector<float>{-0.63212055f, 0, 1, 2}));
+}
+
+TEST(TestCudaRuntime, CudaGraphInvalidatesReplacedStorage) {
+    auto runtime = make_ref<CudaRuntimeObj>();
+    CudaGraphFixture fixture(runtime, 8);
+
+    fixture.run(increasingValues(8));
+    EXPECT_EQ(runtime->getCudaGraphCacheSize(), 1u);
+
+    fixture.reshape(1024);
+    EXPECT_EQ(runtime->getCudaGraphCacheSize(), 0u);
+    fixture.run(increasingValues(1024));
+    EXPECT_EQ(runtime->getCudaGraphCaptureCount(), 2u);
+
+    fixture.reshape(8);
+    fixture.run(increasingValues(8));
+    EXPECT_EQ(runtime->getCudaGraphCaptureCount(), 3u);
+    fixture.graph->trimMemory();
+    EXPECT_EQ(runtime->getCudaGraphCacheSize(), 0u);
+
+    auto values = increasingValues(8, 3);
+    fixture.run(values);
+    EXPECT_EQ(runtime->getCudaGraphCaptureCount(), 4u);
+    EXPECT_TRUE(fixture.outputEquals(values));
+}
+
+TEST(TestCudaRuntime, CudaGraphInvalidatesTopologyChanges) {
+    auto runtime = make_ref<CudaRuntimeObj>();
+    CudaGraphFixture fixture(runtime, 2);
+    fixture.run(increasingValues(2));
+    EXPECT_EQ(runtime->getCudaGraphCacheSize(), 1u);
+
+    auto extraInput = fixture.graph->addTensor({1}, DataType::Float32);
+    extraInput->setInput();
+    EXPECT_EQ(runtime->getCudaGraphCacheSize(), 0u);
+    fixture.graph->dataMalloc();
+    extraInput->copyin(vector<float>{1});
+    fixture.run(increasingValues(2, 2));
+
+    EXPECT_EQ(runtime->getCudaGraphCaptureCount(), 2u);
+    EXPECT_EQ(runtime->getCudaGraphCacheSize(), 1u);
+    EXPECT_TRUE(fixture.outputEquals(increasingValues(2, 2)));
+}
+
+TEST(TestCudaRuntime, CudaGraphUsesBoundedLruCache) {
+    auto runtime = make_ref<CudaRuntimeObj>(0, 2);
+    CudaGraphFixture fixture(runtime, 8);
+
+    fixture.run(increasingValues(8));
+    fixture.reshape(6);
+    fixture.run(increasingValues(6));
+    fixture.reshape(8);
+    fixture.run(increasingValues(8));
+    EXPECT_EQ(runtime->getCudaGraphCaptureCount(), 2u);
+
+    fixture.reshape(4);
+    fixture.run(increasingValues(4));
+    EXPECT_EQ(runtime->getCudaGraphCaptureCount(), 3u);
+    EXPECT_EQ(runtime->getCudaGraphCacheSize(), 2u);
+
+    fixture.reshape(8);
+    fixture.run(increasingValues(8));
+    EXPECT_EQ(runtime->getCudaGraphCaptureCount(), 3u);
+    fixture.reshape(6);
+    fixture.run(increasingValues(6));
+    EXPECT_EQ(runtime->getCudaGraphCaptureCount(), 4u);
+    EXPECT_EQ(runtime->getCudaGraphCacheSize(), 2u);
+}
+
+TEST(TestCudaRuntime, CudaGraphCachesMultipleGraphsPerRuntime) {
+    auto runtime = make_ref<CudaRuntimeObj>();
+    {
+        CudaGraphFixture first(runtime, 2);
+        CudaGraphFixture second(runtime, 3);
+        first.run(increasingValues(2));
+        second.run(increasingValues(3));
+        first.run(increasingValues(2, 10));
+        second.run(increasingValues(3, 20));
+
+        EXPECT_EQ(runtime->getCudaGraphCaptureCount(), 2u);
+        EXPECT_EQ(runtime->getCudaGraphCacheSize(), 2u);
+
+        first.graph.reset();
+        EXPECT_EQ(runtime->getCudaGraphCacheSize(), 1u);
+        second.run(increasingValues(3, 30));
+        EXPECT_EQ(runtime->getCudaGraphCaptureCount(), 2u);
+    }
+    EXPECT_EQ(runtime->getCudaGraphCacheSize(), 0u);
+}
+
+TEST(TestCudaRuntime, CudaGraphSerializesThreadsOnOneRuntime) {
+    auto runtime = make_ref<CudaRuntimeObj>();
+    CudaGraphFixture first(runtime, 2);
+    CudaGraphFixture second(runtime, 3);
+    first.input->copyin(increasingValues(2));
+    second.input->copyin(increasingValues(3));
+    std::atomic<bool> succeeded{true};
+
+    auto worker = [&succeeded](CudaGraphFixture &fixture) {
+        try {
+            for (int i = 0; i < 20; ++i)
+                fixture.runtime->runWithCudaGraph(fixture.graph);
+        } catch (...) {
+            succeeded = false;
+        }
+    };
+    std::thread firstThread(worker, std::ref(first));
+    std::thread secondThread(worker, std::ref(second));
+    firstThread.join();
+    secondThread.join();
+
+    EXPECT_TRUE(succeeded);
+    EXPECT_EQ(runtime->getCudaGraphCaptureCount(), 2u);
+    EXPECT_EQ(runtime->getCudaGraphCacheSize(), 2u);
+}
+
+TEST(TestCudaRuntime, CudaGraphUsesIndependentRuntimeStreams) {
+    auto secondRuntime = make_ref<CudaRuntimeObj>();
+    CudaGraphFixture second(secondRuntime, 3);
+    {
+        auto firstRuntime = make_ref<CudaRuntimeObj>();
+        CudaGraphFixture first(firstRuntime, 2);
+
+        first.run(increasingValues(2));
+        second.run(increasingValues(3));
+        first.run(increasingValues(2, 10));
+        second.run(increasingValues(3, 20));
+
+        EXPECT_EQ(firstRuntime->getCudaGraphCaptureCount(), 1u);
+        EXPECT_TRUE(first.outputEquals(increasingValues(2, 10)));
+    }
+
+    second.run(increasingValues(3, 30));
+    EXPECT_EQ(secondRuntime->getCudaGraphCaptureCount(), 1u);
+    EXPECT_TRUE(second.outputEquals(increasingValues(3, 30)));
+}
+
+TEST(TestCudaRuntime, CudaGraphRecoversAfterCaptureFailure) {
+    auto runtime = make_ref<CudaRuntimeObj>();
+    CudaGraphFixture valid(runtime, 2);
+    valid.run(increasingValues(2));
+
+    Graph invalid = make_ref<GraphObj>(runtime);
+    auto input = invalid->addTensor({2, 2}, DataType::Float32);
+    input->setInput();
+    invalid->addOp<DropoutObj>(input, nullptr, nullptr, 0, false);
+    invalid->dataMalloc();
+    input->copyin(increasingValues(2));
+
+    testing::internal::CaptureStderr();
+    EXPECT_THROW(runtime->runWithCudaGraph(invalid), Exception);
+    const auto cleanupLog = testing::internal::GetCapturedStderr();
+    EXPECT_NE(cleanupLog.find("cudaStreamEndCapture after failure"),
+              string::npos);
+    EXPECT_EQ(runtime->getCudaGraphCaptureCount(), 1u);
+    EXPECT_EQ(runtime->getCudaGraphCacheSize(), 1u);
+
+    valid.run(increasingValues(2, 5));
+    EXPECT_EQ(runtime->getCudaGraphCaptureCount(), 1u);
+    EXPECT_TRUE(valid.outputEquals(increasingValues(2, 5)));
+}
+
+TEST(TestCudaRuntime, CudaGraphCacheCanBeCleared) {
+    EXPECT_THROW(make_ref<CudaRuntimeObj>(0, 0), Exception);
+
+    auto runtime = make_ref<CudaRuntimeObj>();
+    CudaGraphFixture fixture(runtime, 2);
+    fixture.run(increasingValues(2));
+    runtime->clearCudaGraphCache();
+    EXPECT_EQ(runtime->getCudaGraphCacheSize(), 0u);
+    EXPECT_EQ(runtime->getCudaGraphCaptureCount(), 1u);
+
+    fixture.run(increasingValues(2));
+    EXPECT_EQ(runtime->getCudaGraphCaptureCount(), 2u);
 }
 
 } // namespace infini

--- a/test/kernels/cuda/test_cuda_batch_norm.cc
+++ b/test/kernels/cuda/test_cuda_batch_norm.cc
@@ -51,4 +51,36 @@ TEST(CUDA_BatchNorm, run) {
     EXPECT_TRUE(ocpu->equalData(vector<float>{
         -0.5, 0, 0.5, 1, -2, -1, 0, 1, -0.333333, 0, 0.333333, 0.666667}));
 }
+
+TEST(CUDA_BatchNorm, preservesInputShapeDuringRunAndCapture) {
+    auto cudaRuntime = make_ref<CudaRuntimeObj>();
+    Graph graph = make_ref<GraphObj>(cudaRuntime);
+    auto input = graph->addTensor(Shape{2, 3}, DataType::Float32);
+    auto mean = graph->addTensor(Shape{3}, DataType::Float32);
+    auto var = graph->addTensor(Shape{3}, DataType::Float32);
+    auto scale = graph->addTensor(Shape{3}, DataType::Float32);
+    auto bias = graph->addTensor(Shape{3}, DataType::Float32);
+    auto batchNorm = graph->addOp<BatchNormObj>(input, nullptr, mean, var,
+                                                scale, bias, 0.9, 0);
+    graph->dataMalloc();
+
+    input->copyin(vector<float>{0, 1, 2, 3, 4, 5});
+    mean->copyin(vector<float>{0, 1, 2});
+    var->copyin(vector<float>{1, 1, 1});
+    scale->copyin(vector<float>{1, 1, 1});
+    bias->copyin(vector<float>{0, 0, 0});
+    const Shape originalShape{2, 3};
+
+    cudaRuntime->run(graph);
+    EXPECT_EQ(input->getDims(), originalShape);
+    cudaRuntime->runWithCudaGraph(graph);
+    EXPECT_EQ(input->getDims(), originalShape);
+    cudaRuntime->runWithCudaGraph(graph);
+    EXPECT_EQ(input->getDims(), originalShape);
+    EXPECT_EQ(cudaRuntime->getCudaGraphCaptureCount(), 1u);
+
+    auto output =
+        batchNorm->getOutput()->clone(NativeCpuRuntimeObj::getInstance());
+    EXPECT_TRUE(output->equalData(vector<float>{0, 0, 0, 3, 3, 3}));
+}
 } // namespace infini


### PR DESCRIPTION
## 修改说明

本次修改将原有“单 runtime、单 CUDA Graph、状态变化后拒绝执行”的实现，调整为支持动态 shape、多 Graph、多状态缓存和自动重捕获的 runtime 级 CUDA Graph 管理机制。同时完善 storage 生命周期识别、runtime stream、失败恢复和相关 CUDA kernel 行为。

### 1. 建立独立的 CUDA Graph 执行状态

涉及文件：`include/core/graph.h`、`src/core/graph.cc`、`src/core/tensor.cc`、`src/core/tensor_base.cc`

- **原有实现**：使用 `allocationGeneration`、Tensor 地址和 shape 判断 CUDA Graph 是否有效。
- **存在问题**：`allocationGeneration` 主要描述内存分配变化，无法完整表示 Tensor 布局、Graph 拓扑和 storage 生命周期变化。
- **修改后**：新增 `GraphCaptureStateObj`，独立维护 `captureGeneration`、`topologyEpoch` 和 Graph ID。Tensor 使用弱引用关联多个 Graph 的 capture 状态，避免循环引用。

```cpp
class GraphCaptureStateObj {
    uint64_t id;
    Runtime runtime;
    size_t generation = 0;
    size_t topologyEpoch = 0;
};
```

`setShape()` 只在 shape 实际变化时更新状态；`setDataBlob()` 根据 storage、地址和容量是否变化决定是否失效 capture。

### 2. 使用 storage ID 标识底层内存生命周期

涉及文件：`include/core/blob.h`、`src/core/blob.cc`

- **原有实现**：Blob 只记录地址、容量和 owner，CUDA Graph 主要通过数值地址判断内存是否变化。
- **存在问题**：旧内存释放后，新 allocation 可能获得相同地址，但原 CUDA Graph 引用的 storage 已经失效。
- **修改后**：每个 owning Blob 分配唯一 `storageId`，Blob view 继承该 ID，并记录相对于 owning storage 的累计 offset。

```cpp
storageId(nextStorageId.fetch_add(1, std::memory_order_relaxed))
```

因此，即使新 storage 获得相同地址，也不会错误复用旧 capture；同一 pool 内的不同 view 则可以准确识别为同一 storage。

### 3. 合并内存分配过程中的状态更新

涉及文件：`src/core/graph.cc`

- **原有实现**：释放旧 Blob、构造新 storage、迁移数据和提交 view 等步骤可能分别触发状态变化。
- **存在问题**：一次内存调整可能产生多次无意义失效；分配失败并恢复原布局时也可能产生伪状态。
- **修改后**：`dataMalloc()` 开始时记录每个 Tensor 的 storage ID、offset、Blob 容量和地址，完成或异常恢复后再比较最终状态，只提交一次 capture 状态更新。

```cpp
struct CaptureMemoryState {
    uint64_t storageId;
    size_t storageOffset;
    size_t blobBytes;
    const void *address;
};
```

最终布局未变化时不更新 generation；storage 变化时立即清理旧缓存；失败后恢复原布局时不产生伪失效。

### 4. 将单一 CUDA Graph 改为 runtime 级有界 LRU

涉及文件：`include/cuda/cuda_runtime.h`、`src/cuda/cuda_runtime.cc`

- **原有实现**：每个 `CudaRuntimeObj` 只能保存一个 `cudaGraph_t` 和 `cudaGraphExec_t`，更换 Graph 或 shape 后只能拒绝 replay。
- **存在问题**：无法支持动态 shape、多个 Graph 共用 runtime，也无法返回历史 shape 时复用已有 capture。
- **修改后**：每个 runtime 使用有界 LRU 保存多个 capture entry，默认容量为 16，容量按 entry 数量计算。

缓存 key 包含 Graph ID、topology epoch，以及每个 Tensor 的对象身份、dtype、shape、有效字节数、storage ID、offset、Blob 容量和实际地址。

输入值、weight 内容和 activation 中已有的数据不进入 key，因此只修改 Tensor 内容不会触发重新 capture。

### 5. 提供稳定 replay 的 O(1) 快速路径

涉及文件：`src/cuda/cuda_runtime.cc`

- **原有实现**：每次 replay 都遍历全部 Tensor，逐项检查地址和 shape。
- **存在问题**：稳定状态下仍存在 O(T) 检查开销，Tensor 数量较多时会增加 replay 前的 CPU 成本。
- **修改后**：使用 `activeCudaGraphs` 保存每个 Graph 当前活动 entry 和对应 generation。

```cpp
const auto active = activeCudaGraphs.find(graphId);
if (active != activeCudaGraphs.end() &&
    active->second.generation == generation) {
    cudaGraphLaunch(entry->instance, stream);
    syncImpl();
    return;
}
```

generation 未变化时直接 O(1) 命中并 replay；只有状态变化时才执行内存校验、构造 O(T) snapshot 并搜索历史状态。

### 6. 明确 capture 的复用与失效规则

涉及文件：`src/core/graph.cc`、`src/cuda/cuda_runtime.cc`

- **原有实现**：shape 或 allocation generation 变化后直接拒绝执行，无法判断历史 capture 是否仍然合法。
- **存在问题**：同一内存池内 `A -> B -> A` 时，返回 A 后原 capture 仍可能有效；但 storage 已释放时，即使地址相同也必须失效。
- **修改后**：布局变化只更新 generation 并保留历史 entry；storage 或拓扑变化则立即删除该 Graph 的全部缓存。

由此支持：

- 同一 storage 内 `A -> B -> A` 返回 A 时复用历史 capture。
- 输入和 weight 内容变化时继续 replay。
- pool 扩容、trim、weight 移动后清理旧 capture。
- Graph 析构或拓扑变化时主动清理对应 entry。
- 新 storage 获得相同地址时仍重新 capture。

### 7. 调整首次 capture 和失败恢复流程

涉及文件：`src/cuda/cuda_runtime.cc`

- **原有实现**：首次调用只完成 capture 和 instantiate，没有显式 launch 新生成的 graph exec；capture 失败后 stream 可能保持失效状态。
- **存在问题**：第一次调用的执行语义不够清晰，失败后同一 runtime 也难以继续使用。
- **修改后**：未命中缓存时完整 capture 和 instantiate，在本次调用中立即 launch；执行成功后才将 entry 放入缓存。

capture 或 instantiate 失败时会销毁候选 graph、结束失效 capture、重建 runtime stream，并重新绑定 cuDNN/cuBLAS handle。其他 Graph 的合法缓存不会被清除，原始异常继续向调用方抛出，不隐式回退普通执行。

### 8. 将 CUDA stream 调整为 runtime 所有

涉及文件：`include/cuda/cuda_common.h`、`include/cuda/cuda_runtime.h`、`src/cuda/cuda_runtime.cc`

- **原有实现**：`CUDAStream` 使用进程级静态 stream，普通执行可能使用默认 stream；`sync()` 调用 `cudaDeviceSynchronize()`。
- **存在问题**：多个 runtime 会共享全局 stream 状态，一个 runtime 的 capture 或析构可能影响其他 runtime；设备级同步还会等待不属于当前 runtime 的任务。
- **修改后**：每个 `CudaRuntimeObj` 独立持有 RAII stream，并将 cuDNN、cuBLAS handle 绑定到该 stream。`CUDAStream::Guard` 使用线程局部变量向现有 kernel 提供当前 runtime stream。

CUDA Graph capture 使用 `ThreadLocal` 模式：

```cpp
cudaStreamBeginCapture(
    stream,
    cudaStreamCaptureModeThreadLocal
);
```

`ThreadLocal` 仍限制 capture 所在线程中的不安全 CUDA API，但不会像 `Global` 模式一样将限制扩散到其他线程，更符合不同 runtime 独立持有 stream 的设计。

普通执行、tune、CUDA Graph 执行、同步和缓存清理统一使用 runtime 执行锁；同一 runtime 的执行被串行化，不同 runtime 使用各自独立的 stream。`sync()` 只同步当前 runtime stream。

### 9. 扩展 CUDA Graph 缓存接口

涉及文件：`include/cuda/cuda_runtime.h`、`src/ffi/ffi_infinitensor.cc`

- **原有实现**：CUDA runtime 只能指定 device，无法设置缓存容量，也无法查询或主动清理缓存。
- **修改后**：C++ 和 Python 构造函数增加缓存容量参数，并提供缓存管理接口。

```cpp
CudaRuntimeObj(
    int deviceId = 0,
    size_t cudaGraphCacheCapacity = 16
);
```

```python
runtime = backend.CudaRuntime(
    device=0,
    cuda_graph_cache_capacity=16,
)

runtime.clear_cuda_graph_cache()
runtime.cuda_graph_cache_size()
runtime.cuda_graph_capture_count()
```

缓存容量必须大于 0；capture count 记录 runtime 创建以来成功完成的 capture 次数，清空缓存不会重置计数。

### 10. 修复 CUDA BatchNorm 修改 Tensor shape

涉及文件：`src/kernels/cuda/batch_norm.cc`

- **原有实现**：输入维数少于 4 时，BatchNorm kernel 直接调用 `setShape()` 修改 Graph 中的输入 Tensor。
- **存在问题**：kernel 执行期间改变 Graph 元数据会导致 capture 前后状态不一致，并可能访问补维前不存在的 stride 下标。
- **修改后**：使用局部 dimensions 补齐 cuDNN descriptor，并根据局部 shape 重新计算连续 stride，不再修改输入 Tensor。

普通执行、capture 和 replay 前后的输入 shape 现在保持一致。

### 11. 修复 CUDA ELU 使用默认 stream

涉及文件：`src/kernels/cuda/unary.cu`

- **原有实现**：ELU kernel launch 没有显式指定 stream，因此运行在 CUDA 默认 stream。
- **存在问题**：runtime 在独立 stream 上 capture 时，ELU 可能无法被正确记录进 CUDA Graph。
- **修改后**：ELU 使用 `CUDAStream::getCurrentStream()`，与其他 CUDA kernel 保持一致。

```cpp
_elu_kernel<<<gridsize, blocksize, 0,
              CUDAStream::getCurrentStream()>>>(
    input, output, size, alpha);
```